### PR TITLE
TOT-911 Allow participants to rejoin active sessions after 1-hour timeout

### DIFF
--- a/totem/rooms/admin.py
+++ b/totem/rooms/admin.py
@@ -81,18 +81,25 @@ class RoomAdmin(StaleDataCheckAdminMixin, admin.ModelAdmin):
     def session_link(self, obj: Room) -> str:
         from django.urls import reverse
 
-        url = reverse("admin:spaces_session_change", args=[obj.session_id])
+        url = reverse("admin:spaces_session_change", args=[obj.session.id])
         return format_html('<a href="{}">{}</a>', url, obj.session)
 
     @admin.action(description="End selected rooms")
     def end_rooms(self, request, queryset):
         with transaction.atomic():
+            updated_count = 0
             for room in queryset:
                 if room.status != RoomStatus.ENDED:
                     room.status = RoomStatus.ENDED
                     room.save(update_fields=["status"])
-                    # The save_model logic will handle setting session.ended_at
-            self.message_user(request, f"Ended {queryset.count()} room(s).")
+
+                    session = Session.objects.select_for_update().get(pk=room.session.id)
+                    if session.ended_at is None:
+                        session.ended_at = timezone.now()
+                        session.save(update_fields=["ended_at"])
+                    updated_count += 1
+
+            self.message_user(request, f"Ended {updated_count} room(s).")
 
     @override
     def save_model(self, request, obj, form, change):

--- a/totem/rooms/admin.py
+++ b/totem/rooms/admin.py
@@ -40,6 +40,7 @@ class RoomAdmin(StaleDataCheckAdminMixin, admin.ModelAdmin):
         "round_message",
     )
     inlines = [RoomEventLogInline]
+    actions = ["end_rooms"]
 
     fieldsets = (
         (None, {"fields": ("session_link", "status", "end_reason")}),
@@ -82,6 +83,16 @@ class RoomAdmin(StaleDataCheckAdminMixin, admin.ModelAdmin):
 
         url = reverse("admin:spaces_session_change", args=[obj.session_id])
         return format_html('<a href="{}">{}</a>', url, obj.session)
+
+    @admin.action(description="End selected rooms")
+    def end_rooms(self, request, queryset):
+        with transaction.atomic():
+            for room in queryset:
+                if room.status != RoomStatus.ENDED:
+                    room.status = RoomStatus.ENDED
+                    room.save(update_fields=["status"])
+                    # The save_model logic will handle setting session.ended_at
+            self.message_user(request, f"Ended {queryset.count()} room(s).")
 
     @override
     def save_model(self, request, obj, form, change):

--- a/totem/rooms/tests/test_admin.py
+++ b/totem/rooms/tests/test_admin.py
@@ -1,0 +1,135 @@
+from unittest.mock import Mock
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.test import RequestFactory
+from django.utils import timezone
+
+from totem.rooms.admin import RoomAdmin
+from totem.rooms.models import Room
+from totem.rooms.schemas import RoomStatus
+from totem.spaces.tests.factories import SessionFactory, SpaceFactory
+from totem.users.tests.factories import UserFactory
+
+
+@pytest.fixture
+def admin_user(db):
+    return UserFactory(is_staff=True, is_superuser=True)
+
+
+@pytest.fixture
+def admin_site():
+    return AdminSite()
+
+
+@pytest.fixture
+def room_admin(admin_site):
+    return RoomAdmin(Room, admin_site)
+
+
+@pytest.fixture
+def request_factory():
+    return RequestFactory()
+
+
+class TestRoomAdmin:
+    def test_end_rooms_action_ends_selected_rooms(self, db, room_admin, request_factory, admin_user):
+        """Test that the end_rooms action properly ends selected rooms and syncs session.ended_at"""
+        room_admin.message_user = Mock()
+
+        space = SpaceFactory()
+        session1 = SessionFactory(space=space)
+        session2 = SessionFactory(space=space)
+        room1 = Room.objects.create(session=session1, status=RoomStatus.ACTIVE)
+        room2 = Room.objects.create(session=session2, status=RoomStatus.ACTIVE)
+
+        request = request_factory.post("/")
+        request.user = admin_user
+
+        queryset = Room.objects.filter(pk__in=[room1.pk, room2.pk])
+
+        room_admin.end_rooms(request, queryset)
+
+        room1.refresh_from_db()
+        room2.refresh_from_db()
+        session1.refresh_from_db()
+        session2.refresh_from_db()
+
+        assert room1.status == RoomStatus.ENDED
+        assert room2.status == RoomStatus.ENDED
+
+        assert session1.ended_at is not None
+        assert session2.ended_at is not None
+
+        # Assert ended_at is recent (within last minute)
+        now = timezone.now()
+        assert (now - session1.ended_at).total_seconds() < 60
+        assert (now - session2.ended_at).total_seconds() < 60
+
+        # Assert message_user was called
+        room_admin.message_user.assert_called_once_with(request, "Ended 2 room(s).")
+
+    def test_end_rooms_action_skips_already_ended_rooms(self, db, room_admin, request_factory, admin_user):
+        """Test that the end_rooms action skips rooms that are already ended"""
+        room_admin.message_user = Mock()
+
+        space = SpaceFactory()
+        session1 = SessionFactory(space=space)
+        session2 = SessionFactory(space=space, ended_at=timezone.now())
+        room1 = Room.objects.create(session=session1, status=RoomStatus.ACTIVE)
+        room2 = Room.objects.create(session=session2, status=RoomStatus.ENDED)
+
+        request = request_factory.post("/")
+        request.user = admin_user
+
+        queryset = Room.objects.filter(pk__in=[room1.pk, room2.pk])
+
+        room_admin.end_rooms(request, queryset)
+
+        room1.refresh_from_db()
+        room2.refresh_from_db()
+        session1.refresh_from_db()
+        session2.refresh_from_db()
+
+        assert room1.status == RoomStatus.ENDED
+        assert room2.status == RoomStatus.ENDED
+
+        assert session1.ended_at is not None
+        assert session2.ended_at is not None
+
+        # Assert message_user was called with count of actually ended rooms
+        room_admin.message_user.assert_called_once_with(request, "Ended 1 room(s).")
+
+    def test_save_model_syncs_session_ended_at_when_room_ended(self, db, room_admin, request_factory, admin_user):
+        """Test that save_model properly syncs session.ended_at when room status changes to ENDED"""
+        space = SpaceFactory()
+        session = SessionFactory(space=space)
+        room = Room.objects.create(session=session, status=RoomStatus.ACTIVE)
+
+        assert session.ended_at is None
+
+        request = request_factory.post("/")
+        request.user = admin_user
+
+        room.status = RoomStatus.ENDED
+        room_admin.save_model(request, room, None, True)
+
+        session.refresh_from_db()
+
+        assert session.ended_at is not None
+
+    def test_save_model_clears_session_ended_at_when_room_not_ended(self, db, room_admin, request_factory, admin_user):
+        """Test that save_model clears session.ended_at when room status changes from ENDED to something else"""
+        space = SpaceFactory()
+        session = SessionFactory(space=space, ended_at=timezone.now())
+        room = Room.objects.create(session=session, status=RoomStatus.ENDED)
+
+        request = request_factory.post("/")
+        request.user = admin_user
+
+        room.status = RoomStatus.ACTIVE
+        room_admin.save_model(request, room, None, True)
+
+        session.refresh_from_db()
+
+        assert session.ended_at is None

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -259,15 +259,25 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
         now = timezone.now()
         grace_before = datetime.timedelta(minutes=15)
         grace_after = _default_grace_period
-        if user.is_staff or user in self.joined.all():
+
+        is_returning_or_staff = user.is_staff or user in self.joined.all()
+        if is_returning_or_staff:
             # Come back any time if already joined.
             grace_before = datetime.timedelta(minutes=60)
             grace_after = datetime.timedelta(minutes=self.duration_minutes)
+
+            if self.space.meeting_provider == Space.MeetingProviderChoices.LIVEKIT:
+                return self.start - grace_before < now
+
         return self.start - grace_before < now < self.start + grace_after
 
     def ended(self):
         if self.ended_at is not None:
             return True
+        if self.space.meeting_provider == Space.MeetingProviderChoices.LIVEKIT:
+            # For LiveKit sessions, rely on the explicit ended_at timestamp to determine if the session has ended.
+            # This will allow participants to rejoin active sessions after 1-hour timeout.
+            return False
         return self.start + datetime.timedelta(minutes=self.duration_minutes) < timezone.now()
 
     def remove_attendee(self, user):

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -275,7 +275,7 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
         if self.ended_at is not None:
             return True
         if self.space.meeting_provider == Space.MeetingProviderChoices.LIVEKIT:
-            # For LiveKit sessions, rely on the explicit ended_at timestamp to determine if the session has ended.
+            # Rely on the explicit ended_at timestamp to determine if the session has ended.
             # This will allow participants to rejoin active sessions after 1-hour timeout.
             return False
         return self.start + datetime.timedelta(minutes=self.duration_minutes) < timezone.now()

--- a/totem/spaces/tasks.py
+++ b/totem/spaces/tasks.py
@@ -1,9 +1,9 @@
 from datetime import timedelta
 
-from django.db.models import DateTimeField, ExpressionWrapper, F
+from django.db.models import DateTimeField, ExpressionWrapper, F, Q
 from django.utils import timezone
 
-from .models import Session
+from .models import Session, Space
 
 
 def notify_session_ready():
@@ -41,16 +41,20 @@ def advertise_session():
 
 def notify_missed_session():
     now = timezone.now()
-    recently_ended_sessions = Session.objects.alias(
-        end_time=ExpressionWrapper(
-            F("start") + F("duration_minutes") * timedelta(minutes=1),
-            output_field=DateTimeField(),
-        ),
-    ).filter(
-        end_time__gte=now - timedelta(hours=1),
-        end_time__lt=now,
-        cancelled=False,
-        notified_missed=False,
+    recently_ended_sessions = (
+        Session.objects.alias(
+            end_time=ExpressionWrapper(
+                F("start") + F("duration_minutes") * timedelta(minutes=1),
+                output_field=DateTimeField(),
+            ),
+        )
+        .filter(
+            end_time__gte=now - timedelta(hours=1),
+            end_time__lt=now,
+            cancelled=False,
+            notified_missed=False,
+        )
+        .filter(Q(ended_at__isnull=False) | ~Q(space__meeting_provider=Space.MeetingProviderChoices.LIVEKIT))
     )
     print(f"Notifying {len(recently_ended_sessions)} missed sessions")
     for session in recently_ended_sessions:

--- a/totem/spaces/tests/test_models.py
+++ b/totem/spaces/tests/test_models.py
@@ -110,13 +110,15 @@ class TestSessionModel:
 
     def test_can_join_google_meet_within_time(self, db):
         user = UserFactory()
-        session = SessionFactory(start=timezone.now() - datetime.timedelta(minutes=5))
+        space = SpaceFactory(meeting_provider=Space.MeetingProviderChoices.GOOGLE_MEET)
+        session = SessionFactory(space=space, start=timezone.now() - datetime.timedelta(minutes=5))
         session.attendees.add(user)
         assert session.can_join(user)
 
     def test_can_join_google_meet_after_duration(self, db):
         user = UserFactory()
-        session = SessionFactory(start=timezone.now() - datetime.timedelta(hours=2))
+        space = SpaceFactory(meeting_provider=Space.MeetingProviderChoices.GOOGLE_MEET)
+        session = SessionFactory(space=space, start=timezone.now() - datetime.timedelta(hours=2))
         session.attendees.add(user)
         assert not session.can_join(user)
 
@@ -161,4 +163,13 @@ class TestSessionModel:
         session = SessionFactory(space=space, start=timezone.now() - datetime.timedelta(hours=2))
         session.attendees.add(user)
         # Staff can join even if not joined before
+        assert session.can_join(user)
+
+    def test_can_join_livekit_within_60min_before_start(self, db):
+        user = UserFactory()
+        space = SpaceFactory(meeting_provider=Space.MeetingProviderChoices.LIVEKIT)
+        session = SessionFactory(space=space, start=timezone.now() + datetime.timedelta(minutes=30))
+        session.attendees.add(user)
+        session.joined.add(user)
+        # Within 60-min grace_before for joined user
         assert session.can_join(user)

--- a/totem/spaces/tests/test_models.py
+++ b/totem/spaces/tests/test_models.py
@@ -1,9 +1,13 @@
+import datetime
+
 from django.core import mail
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from django.utils import timezone
 
 from totem.users.tests.factories import UserFactory
 
+from ..models import Space
 from ..views import ics_hash
 from .factories import SessionFactory, SpaceFactory
 
@@ -103,3 +107,58 @@ class TestSessionModel:
         assert "http://testserver/spaces/session" in message
         session.refresh_from_db()
         assert session.notified_tomorrow
+
+    def test_can_join_google_meet_within_time(self, db):
+        user = UserFactory()
+        session = SessionFactory(start=timezone.now() - datetime.timedelta(minutes=5))
+        session.attendees.add(user)
+        assert session.can_join(user)
+
+    def test_can_join_google_meet_after_duration(self, db):
+        user = UserFactory()
+        session = SessionFactory(start=timezone.now() - datetime.timedelta(hours=2))
+        session.attendees.add(user)
+        assert not session.can_join(user)
+
+    def test_can_join_livekit_within_time(self, db):
+        user = UserFactory()
+        space = SpaceFactory(meeting_provider=Space.MeetingProviderChoices.LIVEKIT)
+        session = SessionFactory(space=space, start=timezone.now() - datetime.timedelta(minutes=5))
+        session.attendees.add(user)
+        assert session.can_join(user)
+
+    def test_can_join_livekit_after_duration_not_ended(self, db):
+        user = UserFactory()
+        space = SpaceFactory(meeting_provider=Space.MeetingProviderChoices.LIVEKIT)
+        session = SessionFactory(space=space, start=timezone.now() - datetime.timedelta(hours=2))
+        session.attendees.add(user)
+        # Not joined yet, so can't join after duration
+        assert not session.can_join(user)
+
+    def test_can_join_livekit_after_duration_joined_not_ended(self, db):
+        user = UserFactory()
+        space = SpaceFactory(meeting_provider=Space.MeetingProviderChoices.LIVEKIT)
+        session = SessionFactory(space=space, start=timezone.now() - datetime.timedelta(hours=2))
+        session.attendees.add(user)
+        session.joined.add(user)
+        # Joined and not ended, so can rejoin
+        assert session.can_join(user)
+
+    def test_can_join_livekit_after_duration_ended(self, db):
+        user = UserFactory()
+        space = SpaceFactory(meeting_provider=Space.MeetingProviderChoices.LIVEKIT)
+        session = SessionFactory(
+            space=space, start=timezone.now() - datetime.timedelta(hours=2), ended_at=timezone.now()
+        )
+        session.attendees.add(user)
+        session.joined.add(user)
+        # Ended, so can't join
+        assert not session.can_join(user)
+
+    def test_can_join_livekit_staff_after_duration_not_ended(self, db):
+        user = UserFactory(is_staff=True)
+        space = SpaceFactory(meeting_provider=Space.MeetingProviderChoices.LIVEKIT)
+        session = SessionFactory(space=space, start=timezone.now() - datetime.timedelta(hours=2))
+        session.attendees.add(user)
+        # Staff can join even if not joined before
+        assert session.can_join(user)

--- a/totem/spaces/tests/test_tasks.py
+++ b/totem/spaces/tests/test_tasks.py
@@ -5,6 +5,7 @@ from django.core import mail
 from django.utils import timezone
 
 from totem.email.exceptions import EmailBounced
+from totem.spaces.models import Space
 from totem.spaces.tasks import notify_missed_session
 from totem.spaces.tests.factories import SessionFactory, SpaceFactory
 from totem.users.tests.factories import UserFactory
@@ -93,6 +94,34 @@ class TestMissedSessionTask:
         event.attendees.add(user)
         event.save()
         assert event.ended() is True
+        notify_missed_session()
+        event.refresh_from_db()
+        assert event.notified_missed is True
+        assert len(mail.outbox) == 1
+
+    def test_notify_missed_livekit_not_ended(self, db):
+        """LiveKit session that has passed its duration but not explicitly ended should not trigger notify_missed."""
+        space = SpaceFactory(meeting_provider=Space.MeetingProviderChoices.LIVEKIT)
+        event = SessionFactory(space=space, start=timezone.now() - timedelta(hours=1, minutes=30))
+        user = UserFactory()
+        event.attendees.add(user)
+        event.save()
+        assert event.ended() is False  # LiveKit not ended
+        notify_missed_session()
+        event.refresh_from_db()
+        assert event.notified_missed is False
+        assert mail.outbox == []
+
+    def test_notify_missed_livekit_ended(self, db):
+        """LiveKit session that has been explicitly ended should trigger notify_missed even if within duration."""
+        space = SpaceFactory(meeting_provider=Space.MeetingProviderChoices.LIVEKIT)
+        event = SessionFactory(
+            space=space, start=timezone.now() - timedelta(hours=1, minutes=30), ended_at=timezone.now()
+        )
+        user = UserFactory()
+        event.attendees.add(user)
+        event.save()
+        assert event.ended() is True  # Explicitly ended
         notify_missed_session()
         event.refresh_from_db()
         assert event.notified_missed is True


### PR DESCRIPTION
For livekit sessions, remove end time restrictions