### PR TITLE
TOT-1012 Prevent negative session seat counts

### DIFF
--- a/totem/spaces/migrations/0004_session_seats_min_value.py
+++ b/totem/spaces/migrations/0004_session_seats_min_value.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("spaces", "0003_session_ended_at"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="session",
+            name="seats",
+            field=models.IntegerField(
+                default=8,
+                validators=[django.core.validators.MinValueValidator(1)],
+            ),
+        ),
+    ]

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -177,7 +177,7 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
     notified_tomorrow = models.BooleanField(default=False)
     notified_missed = models.BooleanField(default=False)
     open = models.BooleanField(default=True, help_text="Is this session open for more attendees?")
-    seats = models.IntegerField(default=8)
+    seats = models.IntegerField(default=8, validators=[MinValueValidator(1)])
     start = models.DateTimeField(default=timezone.now)
 
     class Meta:  # pyright: ignore [reportIncompatibleVariableOverride]

--- a/totem/spaces/tests/test_models.py
+++ b/totem/spaces/tests/test_models.py
@@ -1,3 +1,4 @@
+import pytest
 from django.core import mail
 from django.core.exceptions import ValidationError
 from django.test import TestCase
@@ -55,6 +56,20 @@ class SpaceModelTest(TestCase):
 
 
 class TestSessionModel:
+    def test_seats_cannot_be_zero(self, db):
+        session = SessionFactory(seats=0)
+        with pytest.raises(ValidationError):
+            session.full_clean()
+
+    def test_seats_cannot_be_negative(self, db):
+        session = SessionFactory(seats=-5)
+        with pytest.raises(ValidationError):
+            session.full_clean()
+
+    def test_seats_minimum_is_one(self, db):
+        session = SessionFactory(seats=1)
+        session.full_clean()  # should not raise
+
     def test_notify(self, db):
         user = UserFactory()
         session = SessionFactory()


### PR DESCRIPTION
## Summary

- Added `MinValueValidator(1)` to the `seats` field on the `Session` model to prevent zero or negative seat counts
- Added migration for the new constraint
- Added tests covering zero, negative, and minimum valid seat values

## Test plan

- [ ] `make test` passes
- [ ] Verify creating a session with `seats=0` or `seats=-1` raises a `ValidationError` on `full_clean()`
- [ ] Verify creating a session with `seats=1` succeeds