### PR TITLE
TOT-1036 Website Redirection

### DIFF
--- a/assets/js/components/detailSidebar.tsx
+++ b/assets/js/components/detailSidebar.tsx
@@ -1,5 +1,3 @@
-import { postData } from "@/libs/postData"
-import { timestampToDateString, timestampToTimeString } from "@/libs/time"
 import { useKeyDownEvent } from "@solid-primitives/keyboard"
 import { useQuery } from "@tanstack/solid-query"
 import {
@@ -12,6 +10,8 @@ import {
   Suspense,
   Switch,
 } from "solid-js"
+import { postData } from "@/libs/postData"
+import { timestampToDateString, timestampToTimeString } from "@/libs/time"
 import { type SessionDetailSchema, totemSpacesApiEventDetail } from "../client"
 import AddToCalendarButton from "./AddToCalendarButton"
 import ErrorBoundary from "./errors"
@@ -21,8 +21,6 @@ import { useTotemTip } from "./tooltip"
 function capitalize(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
-
-
 
 const spacesListLink = "/spaces/"
 
@@ -221,17 +219,6 @@ function EventInfo(props: {
     await postData(props.eventStore.rsvp_url, { action: "remove" })
     props.refetchEvent()
   }
-
-  function isSameOrigin(url?: string | null) {
-    if (!url) return false
-    try {
-      const parsedUrl = new URL(url, window.location.origin)
-      return parsedUrl.hostname === window.location.hostname
-    } catch {
-      return false
-    }
-  }
-
   return (
     <DetailBox>
       <div class="flex flex-wrap justify-between gap-x-4 gap-y-2 pb-2">
@@ -284,7 +271,7 @@ function EventInfo(props: {
             <p class="pb-4">The session is starting soon.</p>
             <a
               class="btn btn-primary w-full"
-              target={isSameOrigin(props.eventStore.join_url) ? "_self" : "_blank"}
+              target="_blank"
               href={props.eventStore.join_url ?? ""}
               rel="noreferrer">
               Enter Space

--- a/assets/js/components/detailSidebar.tsx
+++ b/assets/js/components/detailSidebar.tsx
@@ -1,3 +1,5 @@
+import { postData } from "@/libs/postData"
+import { timestampToDateString, timestampToTimeString } from "@/libs/time"
 import { useKeyDownEvent } from "@solid-primitives/keyboard"
 import { useQuery } from "@tanstack/solid-query"
 import {
@@ -10,8 +12,6 @@ import {
   Suspense,
   Switch,
 } from "solid-js"
-import { postData } from "@/libs/postData"
-import { timestampToDateString, timestampToTimeString } from "@/libs/time"
 import { type SessionDetailSchema, totemSpacesApiEventDetail } from "../client"
 import AddToCalendarButton from "./AddToCalendarButton"
 import ErrorBoundary from "./errors"
@@ -21,6 +21,8 @@ import { useTotemTip } from "./tooltip"
 function capitalize(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
+
+
 
 const spacesListLink = "/spaces/"
 
@@ -219,6 +221,17 @@ function EventInfo(props: {
     await postData(props.eventStore.rsvp_url, { action: "remove" })
     props.refetchEvent()
   }
+
+  function isSameOrigin(url?: string | null) {
+    if (!url) return false
+    try {
+      const parsedUrl = new URL(url, window.location.origin)
+      return parsedUrl.hostname === window.location.hostname
+    } catch {
+      return false
+    }
+  }
+
   return (
     <DetailBox>
       <div class="flex flex-wrap justify-between gap-x-4 gap-y-2 pb-2">
@@ -271,7 +284,7 @@ function EventInfo(props: {
             <p class="pb-4">The session is starting soon.</p>
             <a
               class="btn btn-primary w-full"
-              target="_blank"
+              target={isSameOrigin(props.eventStore.join_url) ? "_self" : "_blank"}
               href={props.eventStore.join_url ?? ""}
               rel="noreferrer">
               Enter Space

--- a/config/urls.py
+++ b/config/urls.py
@@ -15,7 +15,6 @@ from totem.blog.urls import BlogSitemap
 from totem.pages.urls import PagesSitemap
 from totem.plans.urls import PlansSitemap
 from totem.repos.urls import ReposSitemap
-from totem.rooms.proxy import room_app_proxy
 from totem.spaces.urls import SpacesSitemap
 from totem.users import views as user_views
 from totem.utils.exports import get_url_patterns as export_url_patterns
@@ -129,8 +128,7 @@ urlpatterns = [
     path("onboard/", include("totem.onboard.urls")),
     path("dev/", include("totem.dev.urls", namespace="dev")),
     # Reverse-proxy the Flutter web "room" app so it shares this origin.
-    path("room/", room_app_proxy, name="room_app"),
-    path("room/<path:path>", room_app_proxy),
+    path("room/", include("totem.rooms.urls", namespace="rooms")),
     # Redirects
     path("circles/", RedirectView.as_view(url="/spaces/", permanent=True)),
     path("circles/<path:path>", RedirectView.as_view(url="/spaces/%(path)s", permanent=True)),

--- a/totem/rooms/urls.py
+++ b/totem/rooms/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from .proxy import room_app_proxy
+
+app_name = "rooms"
+
+urlpatterns = [
+    path("", room_app_proxy, name="room_app"),
+    path("<path:path>", room_app_proxy, name="room_app_path"),
+]

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -354,6 +354,15 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
     def cal_link(self):
         return full_url(self.get_absolute_url())
 
+    def join_url(self) -> str:
+        match self.space.meeting_provider:
+            case Space.MeetingProviderChoices.LIVEKIT:
+                return full_url(reverse("rooms:room_app_path", kwargs={"path": self.slug}))
+            case Space.MeetingProviderChoices.GOOGLE_MEET:
+                return self.meeting_url
+            case _:
+                return self.meeting_url
+
     def save_to_calendar(self):
         cal_event = calendar.save_event(
             event_id=self.slug,

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -354,7 +354,7 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
     def cal_link(self):
         return full_url(self.get_absolute_url())
 
-    def join_url(self) -> str:
+    def room_url(self) -> str:
         match self.space.meeting_provider:
             case Space.MeetingProviderChoices.LIVEKIT:
                 return full_url(reverse("rooms:room_app_path", kwargs={"path": self.slug}))

--- a/totem/spaces/tests/test_models.py
+++ b/totem/spaces/tests/test_models.py
@@ -130,7 +130,7 @@ class TestSessionModel:
     def test_join_url_google_meet(self, db):
         from ..models import Space
 
-        meeting_url = "https://meet.google.com/abc-defg-hij"
+        meeting_url = "https://example.com"
         space = SpaceFactory(meeting_provider=Space.MeetingProviderChoices.GOOGLE_MEET)
         session = SessionFactory(space=space, meeting_url=meeting_url)
         assert session.join_url() == meeting_url

--- a/totem/spaces/tests/test_models.py
+++ b/totem/spaces/tests/test_models.py
@@ -118,3 +118,19 @@ class TestSessionModel:
         assert "http://testserver/spaces/session" in message
         session.refresh_from_db()
         assert session.notified_tomorrow
+
+    def test_join_url_livekit(self, db):
+        from ..models import Space
+
+        space = SpaceFactory(meeting_provider=Space.MeetingProviderChoices.LIVEKIT)
+        session = SessionFactory(space=space)
+        url = session.join_url()
+        assert f"/room/{session.slug}" in url
+
+    def test_join_url_google_meet(self, db):
+        from ..models import Space
+
+        meeting_url = "https://meet.google.com/abc-defg-hij"
+        space = SpaceFactory(meeting_provider=Space.MeetingProviderChoices.GOOGLE_MEET)
+        session = SessionFactory(space=space, meeting_url=meeting_url)
+        assert session.join_url() == meeting_url

--- a/totem/spaces/tests/test_models.py
+++ b/totem/spaces/tests/test_models.py
@@ -124,7 +124,7 @@ class TestSessionModel:
 
         space = SpaceFactory(meeting_provider=Space.MeetingProviderChoices.LIVEKIT)
         session = SessionFactory(space=space)
-        url = session.join_url()
+        url = session.room_url()
         assert f"/room/{session.slug}" in url
 
     def test_join_url_google_meet(self, db):
@@ -133,4 +133,4 @@ class TestSessionModel:
         meeting_url = "https://example.com"
         space = SpaceFactory(meeting_provider=Space.MeetingProviderChoices.GOOGLE_MEET)
         session = SessionFactory(space=space, meeting_url=meeting_url)
-        assert session.join_url() == meeting_url
+        assert session.room_url() == meeting_url

--- a/totem/spaces/tests/test_views.py
+++ b/totem/spaces/tests/test_views.py
@@ -174,7 +174,7 @@ class TestJoinView:
         client.force_login(user)
         response = client.get(reverse("spaces:join", kwargs={"session_slug": event.slug}))
         assert response.status_code == 302
-        assert event.join_url() in response.url
+        assert event.room_url() in response.url
         assert user in event.joined.all()
 
     def test_join_attending_late(self, client, db):
@@ -201,7 +201,7 @@ class TestJoinView:
         url = JoinSessionAction(user=user, parameters={"session_slug": event.slug}).build_url()
         response = client.get(url)
         assert response.status_code == 302
-        assert event.join_url() in response.url
+        assert event.room_url() in response.url
         assert user in event.joined.all()
 
 

--- a/totem/spaces/tests/test_views.py
+++ b/totem/spaces/tests/test_views.py
@@ -174,7 +174,7 @@ class TestJoinView:
         client.force_login(user)
         response = client.get(reverse("spaces:join", kwargs={"session_slug": event.slug}))
         assert response.status_code == 302
-        assert event.meeting_url in response.url
+        assert event.join_url() in response.url
         assert user in event.joined.all()
 
     def test_join_attending_late(self, client, db):
@@ -185,6 +185,7 @@ class TestJoinView:
         event.add_attendee(user)
         client.force_login(user)
         event.start = timezone.now() - datetime.timedelta(minutes=30)
+        event.save()
         response = client.get(reverse("spaces:join", kwargs={"session_slug": event.slug}))
         assert response.status_code == 302
         assert event.slug in response.url
@@ -200,7 +201,7 @@ class TestJoinView:
         url = JoinSessionAction(user=user, parameters={"session_slug": event.slug}).build_url()
         response = client.get(url)
         assert response.status_code == 302
-        assert event.meeting_url in response.url
+        assert event.join_url() in response.url
         assert user in event.joined.all()
 
 

--- a/totem/spaces/views.py
+++ b/totem/spaces/views.py
@@ -157,7 +157,7 @@ def join(request, session_slug):
     if session.can_join(user):
         session.joined.add(user)
         analytics.event_joined(user, session)
-        return redirect(session.join_url(), permanent=False)
+        return redirect(session.room_url(), permanent=False)
 
     if session.started():
         messages.info(request, "This session has already started.")

--- a/totem/spaces/views.py
+++ b/totem/spaces/views.py
@@ -157,7 +157,7 @@ def join(request, session_slug):
     if session.can_join(user):
         session.joined.add(user)
         analytics.event_joined(user, session)
-        return redirect(session.meeting_url, permanent=False)
+        return redirect(session.join_url(), permanent=False)
 
     if session.started():
         messages.info(request, "This session has already started.")


### PR DESCRIPTION
When meeting provider is livekit, open `./room/{session_slug}` instead of opening google meet link.