### PR TITLE
Give the next-session button room to breathe

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,10 @@ repos:
       - id: build-assets
         name: build-assets
         entry: bun run build
-        language: node
+        # `system` uses the bun already on PATH (and the repo's node_modules).
+        # `node` would need pre-commit to build an isolated env, which it
+        # refuses to do for local hooks without additional_dependencies.
+        language: system
         pass_filenames: false
 
 # sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date

--- a/assets/js/components/detailSidebar.test.tsx
+++ b/assets/js/components/detailSidebar.test.tsx
@@ -78,8 +78,25 @@ test("started session links to the space's next session", () => {
       },
     })
   )
-  const link = result.getByText(/Next session:/)
+  const link = result.getByRole("link", { name: /next session/i })
   expect(link.getAttribute("href")).toBe("/spaces/session/next-session/")
+})
+
+test("next session button uses the short date so it fits on one line", () => {
+  const result = renderEventInfo(
+    makeEvent({
+      ended: true,
+      next_session: {
+        slug: "next-session",
+        // A Tuesday, so the long format would read "Tuesday, January 8th".
+        start: "2030-01-08T18:00:00.000Z",
+        link: "/spaces/session/next-session/",
+      },
+    })
+  )
+  const link = result.getByRole("link", { name: /next session/i })
+  expect(link.textContent).toContain("Tue, Jan 8")
+  expect(link.textContent).not.toContain("Tuesday")
 })
 
 test("started session without a next session falls back to the spaces list", () => {

--- a/assets/js/components/detailSidebar.tsx
+++ b/assets/js/components/detailSidebar.tsx
@@ -11,7 +11,11 @@ import {
   Switch,
 } from "solid-js"
 import { postData, postErrorMessage } from "@/libs/postData"
-import { timestampToDateString, timestampToTimeString } from "@/libs/time"
+import {
+  timestampToDateString,
+  timestampToDateStringShort,
+  timestampToTimeString,
+} from "@/libs/time"
 import {
   type SessionDetailSchema,
   totemSpacesApiEventDetail,
@@ -228,8 +232,14 @@ function NextSessionLink(props: { next?: UpcomingSessionSchema | null }) {
         </a>
       }>
       {(next) => (
-        <a class="btn btn-primary mt-4 w-full" href={next().link}>
-          Next session: {timestampToDateString(next().start)}
+        <a
+          class="btn btn-primary mt-4 h-auto w-full flex-col gap-0.5 py-2 leading-tight"
+          href={next().link}>
+          <span class="text-xs font-normal opacity-80">Next session</span>
+          <span class="flex items-center gap-1.5">
+            <Icon name="calendar" size={16} />
+            {timestampToDateStringShort(next().start)}
+          </span>
         </a>
       )}
     </Show>


### PR DESCRIPTION
The long date filled the button and wrapped onto a second line. Stack a small label over a short date with a calendar icon so it fits on one line.