### PR TITLE
Add a participant insights page to the session admin

### DIFF
--- a/totem/spaces/admin.py
+++ b/totem/spaces/admin.py
@@ -4,16 +4,18 @@ from typing import Any, final, override
 from django.contrib import admin, messages
 from django.db.models.query import QuerySet
 from django.forms import ModelForm
-from django.http import HttpRequest
-from django.shortcuts import redirect
-from django.urls import reverse
+from django.http import Http404, HttpRequest, HttpResponse
+from django.shortcuts import redirect, render
+from django.urls import URLPattern, URLResolver, path, reverse
 from django.utils import timezone
+from django.utils.html import format_html
 
 from totem.rooms.models import Room
 from totem.users.models import User
 from totem.utils.admin import StaleDataCheckAdminMixin
 
 from .models import Session, SessionFeedback, Space, SpaceCategory
+from .participants import participant_insights
 
 
 @final
@@ -161,9 +163,41 @@ class SessionAdmin(StaleDataCheckAdminMixin, admin.ModelAdmin):
     list_display = ("start", "title", "space", "slug")
     list_filter = [AuthorDropdownFilter, SpaceDropdownFilter, "start", "listed", "open", "cancelled"]
     autocomplete_fields = ["attendees", "joined"]
-    readonly_fields = ("attendee_email_list", "date_created", "date_modified", "room_link")
+    readonly_fields = ("attendee_email_list", "participants_link", "date_created", "date_modified", "room_link")
     actions = [copy_session]
     inlines = [SessionFeedbackInline]
+
+    @override
+    def get_urls(self) -> list[URLPattern | URLResolver]:
+        custom_urls = [
+            path(
+                "<int:object_id>/participants/",
+                self.admin_site.admin_view(self.participants_view),
+                name="spaces_session_participants",
+            ),
+        ]
+        return custom_urls + super().get_urls()
+
+    def participants_view(self, request: HttpRequest, object_id: int) -> HttpResponse:
+        session = self.get_object(request, str(object_id))
+        if session is None or not self.has_view_permission(request, session):
+            raise Http404("Session not found")
+        context = {
+            **self.admin_site.each_context(request),
+            "title": f"Participants: {session.session_title_or_title()}",
+            "opts": self.model._meta,
+            "session": session,
+            "participants": participant_insights(session),
+            "session_change_url": reverse("admin:spaces_session_change", args=[session.pk]),
+        }
+        return render(request, "admin/spaces/session_participants.html", context)
+
+    @admin.display(description="Participants")
+    def participants_link(self, obj: Session) -> str:
+        if not obj.pk:
+            return "Save the session first"
+        url = reverse("admin:spaces_session_participants", args=[obj.pk])
+        return format_html('<a href="{}">View participant insights</a>', url)
 
     @override
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
@@ -184,6 +218,7 @@ class SessionAdmin(StaleDataCheckAdminMixin, admin.ModelAdmin):
                     "content",
                     "attendees",
                     "attendee_email_list",
+                    "participants_link",
                     "joined",
                     "meeting_url",
                 )

--- a/totem/spaces/participants.py
+++ b/totem/spaces/participants.py
@@ -1,0 +1,92 @@
+"""Read-only participant insights for the Session admin.
+
+Keepers and admins use this to see who is signed up for a Session and how
+reliably they've shown up in the past, without digging through the raw
+attendee/joined many-to-many fields.
+"""
+
+from dataclasses import dataclass
+
+from django.db.models import Count, Q
+from django.utils import timezone
+
+from totem.rooms.models import Room
+from totem.users.models import User
+
+from .models import Session
+
+
+@dataclass(frozen=True)
+class ParticipantInsight:
+    pk: int
+    slug: str
+    name: str
+    email: str
+    #: Earlier sessions this person signed up for, excluding cancelled ones.
+    rsvps: int
+    #: Earlier sessions this person actually joined.
+    attended: int
+    #: Banned from some other session.
+    banned: bool
+    joined_this_session: bool
+
+    @property
+    def attendance_percent(self) -> int:
+        if not self.rsvps:
+            return 0
+        return round(100 * self.attended / self.rsvps)
+
+    @property
+    def first_time(self) -> bool:
+        """Never joined a Space. A no-show RSVP doesn't count as attending."""
+        return self.attended == 0
+
+
+def _globally_banned_slugs(slugs: list[str]) -> set[str]:
+    """Which of these users are banned from any session's room, anywhere."""
+    if not slugs:
+        return set()
+    banned_lists = Room.objects.filter(banned_participants__overlap=slugs).values_list("banned_participants", flat=True)
+    return {slug for banned in banned_lists for slug in banned} & set(slugs)
+
+
+def participant_insights(session: Session) -> list[ParticipantInsight]:
+    now = timezone.now()
+
+    def history(relation: str) -> Q:
+        """Sessions that count towards a person's record: earlier than this one,
+        and not cancelled. A session is never part of its own history, or a
+        first-timer would lose the badge the moment they joined."""
+        return Q(**{f"{relation}__start__lt": now, f"{relation}__cancelled": False}) & ~Q(
+            **{f"{relation}__pk": session.pk}
+        )
+
+    # Select by pk rather than annotating session.attendees directly: filtering on
+    # sessions_attending would make the annotation reuse that same (session-scoped) join.
+    attendee_ids = list(session.attendees.values_list("pk", flat=True))
+    rows = list(
+        User.objects.filter(pk__in=attendee_ids)
+        .annotate(
+            rsvp_count=Count("sessions_attending", filter=history("sessions_attending"), distinct=True),
+            attended_count=Count("sessions_joined", filter=history("sessions_joined"), distinct=True),
+        )
+        .order_by("name", "email")
+        .values("pk", "slug", "name", "email", "rsvp_count", "attended_count")
+    )
+    banned = _globally_banned_slugs([row["slug"] for row in rows])
+    joined = set(session.joined.values_list("slug", flat=True))
+    return [
+        ParticipantInsight(
+            pk=row["pk"],
+            slug=row["slug"],
+            name=row["name"],
+            email=row["email"],
+            # Someone can be dropped from attendees after the fact, so a join with no
+            # RSVP is possible. Count it as a signup rather than report 1 out of 0.
+            rsvps=max(row["rsvp_count"], row["attended_count"]),
+            attended=row["attended_count"],
+            banned=row["slug"] in banned,
+            joined_this_session=row["slug"] in joined,
+        )
+        for row in rows
+    ]

--- a/totem/spaces/tests/test_admin.py
+++ b/totem/spaces/tests/test_admin.py
@@ -1,4 +1,8 @@
+import datetime
+
+import pytest
 from django.urls import reverse
+from django.utils import timezone
 
 from totem.users.tests.factories import UserFactory
 
@@ -16,3 +20,64 @@ class TestSessionAdmin:
         assert response.status_code == 200
         assert user1.email in response.content.decode()
         assert user2.email in response.content.decode()
+
+    def test_change_page_links_to_participants(self, admin_client):
+        session = SessionFactory()
+        url = reverse("admin:spaces_session_change", kwargs={"object_id": session.pk})
+        response = admin_client.get(url)
+        assert reverse("admin:spaces_session_participants", args=[session.pk]) in response.content.decode()
+
+    def test_add_page_renders(self, admin_client):
+        # The participants link can't be built before the session has a pk.
+        assert admin_client.get(reverse("admin:spaces_session_add")).status_code == 200
+
+
+@pytest.mark.django_db
+class TestSessionParticipantsView:
+    def test_shows_participant_details(self, admin_client):
+        session = SessionFactory()
+        user = UserFactory(name="Claire")
+        session.attendees.add(user)
+        past = SessionFactory(start=timezone.now() - datetime.timedelta(days=7))
+        past.attendees.add(user)
+        past.joined.add(user)
+
+        url = reverse("admin:spaces_session_participants", args=[session.pk])
+        response = admin_client.get(url)
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "Claire" in content
+        assert user.email in content
+        assert "100%" in content
+        assert "1/1" in content
+
+    def test_first_time_badge(self, admin_client):
+        session = SessionFactory()
+        session.attendees.add(UserFactory(name="Nate"))
+
+        url = reverse("admin:spaces_session_participants", args=[session.pk])
+        content = admin_client.get(url).content.decode()
+
+        assert "First time" in content
+        # Nobody with an empty record should be shown a meaningless "0% · 0/0".
+        assert "No history" in content
+        assert "0/0" not in content
+
+    def test_missing_session_is_404(self, admin_client):
+        url = reverse("admin:spaces_session_participants", args=[123456])
+        assert admin_client.get(url).status_code == 404
+
+    def test_staff_without_session_permission_is_404(self, client):
+        session = SessionFactory()
+        client.force_login(UserFactory(is_staff=True))
+        url = reverse("admin:spaces_session_participants", args=[session.pk])
+        assert client.get(url).status_code == 404
+
+    def test_requires_staff(self, client):
+        session = SessionFactory()
+        client.force_login(UserFactory())
+        url = reverse("admin:spaces_session_participants", args=[session.pk])
+        response = client.get(url)
+        assert response.status_code == 302
+        assert "/admin/login/" in response.url

--- a/totem/spaces/tests/test_participants.py
+++ b/totem/spaces/tests/test_participants.py
@@ -1,0 +1,150 @@
+import datetime
+
+import pytest
+from django.utils import timezone
+
+from totem.rooms.models import Room
+from totem.users.tests.factories import UserFactory
+
+from ..participants import participant_insights
+from .factories import SessionFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def past_session(**kwargs):
+    return SessionFactory(start=timezone.now() - datetime.timedelta(days=7), **kwargs)
+
+
+class TestParticipantInsights:
+    def test_lists_attendees_with_name_and_email(self):
+        session = SessionFactory()
+        user = UserFactory(name="Claire")
+        session.attendees.add(user)
+
+        (insight,) = participant_insights(session)
+
+        assert insight.name == "Claire"
+        assert insight.email == user.email
+        assert insight.slug == user.slug
+
+    def test_counts_past_rsvps_and_attendance(self):
+        session = SessionFactory()
+        user = UserFactory()
+        session.attendees.add(user)
+        for _ in range(4):
+            past = past_session()
+            past.attendees.add(user)
+        attended = past_session()
+        attended.attendees.add(user)
+        attended.joined.add(user)
+
+        (insight,) = participant_insights(session)
+
+        assert insight.rsvps == 5
+        assert insight.attended == 1
+        assert insight.attendance_percent == 20
+
+    def test_upcoming_sessions_do_not_count_as_rsvps(self):
+        session = SessionFactory()
+        user = UserFactory()
+        session.attendees.add(user)
+        upcoming = SessionFactory(start=timezone.now() + datetime.timedelta(days=1))
+        upcoming.attendees.add(user)
+
+        (insight,) = participant_insights(session)
+
+        assert insight.rsvps == 0
+        assert insight.attendance_percent == 0
+
+    def test_cancelled_sessions_are_not_held_against_anyone(self):
+        session = SessionFactory()
+        user = UserFactory()
+        session.attendees.add(user)
+        cancelled = past_session(cancelled=True)
+        cancelled.attendees.add(user)
+        attended = past_session()
+        attended.attendees.add(user)
+        attended.joined.add(user)
+
+        (insight,) = participant_insights(session)
+
+        assert insight.rsvps == 1
+        assert insight.attendance_percent == 100
+
+    def test_the_session_being_viewed_is_not_part_of_its_own_history(self):
+        session = past_session()
+        user = UserFactory()
+        session.attendees.add(user)
+        session.joined.add(user)
+
+        (insight,) = participant_insights(session)
+
+        assert insight.rsvps == 0
+        assert insight.attended == 0
+        assert insight.first_time is True
+        assert insight.joined_this_session is True
+
+    def test_joining_without_an_rsvp_still_counts_as_a_signup(self):
+        # attendees and joined are independent, so someone can be removed from
+        # attendees after the fact. Never report more attended than RSVPed.
+        session = SessionFactory()
+        user = UserFactory()
+        session.attendees.add(user)
+        past = past_session()
+        past.joined.add(user)
+
+        (insight,) = participant_insights(session)
+
+        assert insight.attended == 1
+        assert insight.rsvps == 1
+        assert insight.attendance_percent == 100
+
+    def test_first_time_when_never_attended(self):
+        session = SessionFactory()
+        newcomer = UserFactory()
+        regular = UserFactory()
+        session.attendees.add(newcomer, regular)
+        # A no-show RSVP does not make someone a returning participant.
+        no_show = past_session()
+        no_show.attendees.add(newcomer)
+        attended = past_session()
+        attended.attendees.add(regular)
+        attended.joined.add(regular)
+
+        insights = {i.slug: i for i in participant_insights(session)}
+
+        assert insights[newcomer.slug].first_time is True
+        assert insights[regular.slug].first_time is False
+
+    def test_banned_from_another_space(self):
+        session = SessionFactory()
+        banned_user = UserFactory()
+        other_user = UserFactory()
+        session.attendees.add(banned_user, other_user)
+        other_session = past_session()
+        Room.objects.create(
+            session=other_session,
+            keeper=other_session.space.author.slug,
+            banned_participants=[banned_user.slug],
+        )
+
+        insights = {i.slug: i for i in participant_insights(session)}
+
+        assert insights[banned_user.slug].banned is True
+        assert insights[other_user.slug].banned is False
+
+    def test_joined_this_session(self):
+        session = past_session()
+        joiner = UserFactory()
+        absent = UserFactory()
+        session.attendees.add(joiner, absent)
+        session.joined.add(joiner)
+
+        insights = {i.slug: i for i in participant_insights(session)}
+
+        assert insights[joiner.slug].joined_this_session is True
+        assert insights[absent.slug].joined_this_session is False
+
+    def test_no_attendees(self):
+        assert participant_insights(SessionFactory()) == []

--- a/totem/templates/admin/spaces/session_participants.html
+++ b/totem/templates/admin/spaces/session_participants.html
@@ -1,0 +1,82 @@
+{% extends "admin/base_site.html" %}
+
+{% block breadcrumbs %}
+  <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">Home</a>
+    &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+    &rsaquo; <a href="{% url 'admin:spaces_session_changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+    &rsaquo; <a href="{{ session_change_url }}">{{ session }}</a>
+    &rsaquo; Participants
+  </div>
+{% endblock %}
+
+{% block extrahead %}
+  {{ block.super }}
+  <style>
+    .participant-badge {
+      display: inline-block;
+      padding: 1px 8px;
+      margin-right: 4px;
+      border-radius: 10px;
+      font-size: 11px;
+      white-space: nowrap;
+      border: 1px solid var(--border-color);
+      color: var(--body-fg);
+    }
+    .participant-badge.first-time { border-color: var(--primary); }
+    .participant-badge.banned { border-color: var(--error-fg); color: var(--error-fg); }
+    .participant-ratio { color: var(--body-quiet-color); }
+    .participant-meta { margin-bottom: 12px; color: var(--body-quiet-color); }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <p class="participant-meta">
+    {{ session.space.title }} &middot; {{ session.start|date:"D M j, Y, P e" }} &middot;
+    {{ participants|length }} signed up, {{ session.seats_left }} seat{{ session.seats_left|pluralize }} left
+  </p>
+
+  <div class="results">
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">Name</th>
+          <th scope="col">Email</th>
+          <th scope="col">Attendance</th>
+          <th scope="col">Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for participant in participants %}
+          <tr>
+            <th scope="row">
+              {% if perms.users.change_user %}
+                <a href="{% url 'admin:users_user_change' participant.pk %}">{{ participant.name|default:participant.email }}</a>
+              {% else %}
+                {{ participant.name|default:participant.email }}
+              {% endif %}
+            </th>
+            <td>{{ participant.email }}</td>
+            <td>
+              {% if participant.rsvps %}
+                {{ participant.attendance_percent }}%
+                <span class="participant-ratio">&middot; {{ participant.attended }}/{{ participant.rsvps }}</span>
+              {% else %}
+                <span class="participant-ratio">No history</span>
+              {% endif %}
+            </td>
+            <td>
+              {% if participant.first_time %}<span class="participant-badge first-time">First time</span>{% endif %}
+              {% if participant.banned %}<span class="participant-badge banned">Banned from a session</span>{% endif %}
+              {% if participant.joined_this_session %}<span class="participant-badge">Joined</span>{% endif %}
+            </td>
+          </tr>
+        {% empty %}
+          <tr><td colspan="4">Nobody has signed up yet.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <p><a href="{{ session_change_url }}">&larr; Back to session</a></p>
+{% endblock %}


### PR DESCRIPTION
Keepers reviewing a session had to read the raw attendees and joined many-to-many widgets to work out who was coming and whether they tend to show up. This adds a read-only page, linked from the session change form, listing each participant with their attendance record and status badges.

Attendance is derived from data we already have, so there's no migration: RSVPs come from attendees, attendance from joined, and bans from Room.banned_participants. A person's record covers only earlier, non-cancelled sessions. Excluding the current session matters more than it sounds: otherwise a first-timer loses the "First time" badge the moment they join, which is exactly when a keeper is likely to have the page open. Cancelled sessions are excluded so calling one off doesn't permanently deflate every signup's rate.

Attendees and joined are independent, so someone can be in joined without an RSVP; that counts as a signup rather than rendering "1/0". People with no history read "No history" instead of a meaningless "0% - 0/0".

Counting is done over users selected by pk rather than by annotating session.attendees directly, since filtering the related manager makes the annotation reuse that same session-scoped join and silently zero the counts.

The structured internal notes and pronouns from TOT-1182 are left out; both need new fields.