### PR TITLE
Increment round number when round completes

### DIFF
--- a/totem/rooms/state_machine.py
+++ b/totem/rooms/state_machine.py
@@ -322,8 +322,10 @@ def _handle_accept(room: Room, actor: str, connected: set[str]) -> None:
             message="You are not the next speaker",
         )
 
-    if actor == room.keeper:
-        # The stick has returned to the keeper, so a new round begins.
+    if actor == room.keeper and room.current_speaker != room.keeper:
+        # The stick returned to the keeper from another participant, so a
+        # full lap completed and a new round begins. A solo keeper passing
+        # to themselves is not a lap.
         room.round_number += 1
         room.round_message = None
 

--- a/totem/rooms/state_machine.py
+++ b/totem/rooms/state_machine.py
@@ -277,11 +277,11 @@ def _handle_pass(room: Room, actor: str, connected: set[str], prompt: str | None
             message="Only the keeper can set a round prompt",
         )
 
-    keeper_starts_round = (
+    keeper_passes_from_turn = (
         actor == room.keeper and room.current_speaker == room.keeper and room.turn_state == TurnState.SPEAKING
     )
 
-    if prompt is not None and not keeper_starts_round:
+    if prompt is not None and not keeper_passes_from_turn:
         raise TransitionError(
             code=ErrorCode.INVALID_TRANSITION,
             message="Round prompt can only be set when keeper passes from their own turn",
@@ -301,8 +301,7 @@ def _handle_pass(room: Room, actor: str, connected: set[str], prompt: str | None
 
         room.next_speaker = next_slug
     else:
-        if keeper_starts_round:
-            room.round_number += 1
+        if keeper_passes_from_turn and prompt is not None:
             room.round_message = prompt
         room.turn_state = TurnState.PASSING
 
@@ -322,6 +321,11 @@ def _handle_accept(room: Room, actor: str, connected: set[str]) -> None:
             code=ErrorCode.NOT_NEXT_SPEAKER,
             message="You are not the next speaker",
         )
+
+    if actor == room.keeper:
+        # The stick has returned to the keeper, so a new round begins.
+        room.round_number += 1
+        room.round_message = None
 
     next_slug = _next_in_order(room.talking_order, actor, connected)
 

--- a/totem/rooms/tests/test_api.py
+++ b/totem/rooms/tests/test_api.py
@@ -292,7 +292,7 @@ class TestPostEvent:
 
         assert resp.status_code == 200
         data = resp.json()
-        assert data["round_number"] == 2
+        assert data["round_number"] == 1
         assert data["round_message"] == "What are you carrying today?"
 
     def test_set_prompt(self, client_with_user: tuple[Client, User]):

--- a/totem/rooms/tests/test_state_machine.py
+++ b/totem/rooms/tests/test_state_machine.py
@@ -345,7 +345,7 @@ class TestPassStick:
         state = apply_event(slug, keeper.slug, PassStickEvent(prompt="What did you learn this week?"), 1, connected)
 
         assert state.turn_state == TurnState.PASSING
-        assert state.round_number == 2
+        assert state.round_number == 1
         assert state.round_message == "What did you learn this week?"
 
     def test_non_keeper_pass_does_not_increment_round(self):
@@ -361,7 +361,7 @@ class TestPassStick:
 
         state = apply_event(slug, user1.slug, PassStickEvent(), 3, connected)
 
-        assert state.round_number == 2
+        assert state.round_number == 1
         assert state.round_message == "Round 2 prompt"
 
     def test_non_keeper_cannot_set_prompt_when_passing(self):
@@ -424,7 +424,7 @@ class TestPassStick:
 
         state = apply_event(slug, keeper.slug, PassStickEvent(), 7, connected)
 
-        assert state.round_number == 3
+        assert state.round_number == 2
         assert state.round_message is None
 
     def test_keeper_pass_empty_string_clears_round_message(self):
@@ -444,8 +444,76 @@ class TestPassStick:
 
         state = apply_event(slug, keeper.slug, PassStickEvent(prompt=""), 7, connected)
 
-        assert state.round_number == 3
+        assert state.round_number == 2
         assert state.round_message is None
+
+    def test_start_prompt_survives_first_pass(self):
+        keeper = UserFactory()
+        user1 = UserFactory()
+        user2 = UserFactory()
+        _, slug = _setup_room(keeper, [keeper, user1, user2])
+        connected = {keeper.slug, user1.slug, user2.slug}
+
+        started = apply_event(slug, keeper.slug, StartRoomEvent(prompt="Opening prompt"), 0, connected)
+        assert started.round_number == 1
+        assert started.round_message == "Opening prompt"
+
+        state = apply_event(slug, keeper.slug, PassStickEvent(), 1, connected)
+
+        assert state.round_number == 1
+        assert state.round_message == "Opening prompt"
+
+        state = apply_event(slug, user1.slug, AcceptStickEvent(), 2, connected)
+        state = apply_event(slug, user1.slug, PassStickEvent(), 3, connected)
+
+        assert state.round_number == 1
+        assert state.round_message == "Opening prompt"
+
+    def test_start_prompt_replaced_by_first_pass_prompt(self):
+        keeper = UserFactory()
+        user1 = UserFactory()
+        user2 = UserFactory()
+        _, slug = _setup_room(keeper, [keeper, user1, user2])
+        connected = {keeper.slug, user1.slug, user2.slug}
+
+        apply_event(slug, keeper.slug, StartRoomEvent(prompt="Opening prompt"), 0, connected)
+
+        state = apply_event(slug, keeper.slug, PassStickEvent(prompt="New prompt"), 1, connected)
+
+        assert state.round_number == 1
+        assert state.round_message == "New prompt"
+
+    def test_start_prompt_visible_to_next_speaker(self):
+        keeper = UserFactory()
+        user1 = UserFactory()
+        _, slug = _setup_room(keeper, [keeper, user1])
+        connected = {keeper.slug, user1.slug}
+
+        apply_event(slug, keeper.slug, StartRoomEvent(prompt="Opening prompt"), 0, connected)
+        apply_event(slug, keeper.slug, PassStickEvent(), 1, connected)
+
+        state = apply_event(slug, user1.slug, AcceptStickEvent(), 2, connected)
+
+        assert state.round_message == "Opening prompt"
+
+    def test_round_increments_after_full_cycle(self):
+        keeper = UserFactory()
+        user1 = UserFactory()
+        user2 = UserFactory()
+        _, slug = _setup_room(keeper, [keeper, user1, user2])
+        connected = {keeper.slug, user1.slug, user2.slug}
+
+        apply_event(slug, keeper.slug, StartRoomEvent(), 0, connected)
+        apply_event(slug, keeper.slug, PassStickEvent(), 1, connected)
+        apply_event(slug, user1.slug, AcceptStickEvent(), 2, connected)
+        apply_event(slug, user1.slug, PassStickEvent(), 3, connected)
+        apply_event(slug, user2.slug, AcceptStickEvent(), 4, connected)
+        apply_event(slug, user2.slug, PassStickEvent(), 5, connected)
+
+        # The stick returns to the keeper. Round 1 completes.
+        state = apply_event(slug, keeper.slug, AcceptStickEvent(), 6, connected)
+
+        assert state.round_number == 2
 
 
 @pytest.mark.django_db
@@ -565,7 +633,7 @@ class TestSetPrompt:
         state = apply_event(slug, keeper.slug, SetPromptEvent(prompt="Revised prompt"), 2, connected)
 
         assert state.round_message == "Revised prompt"
-        assert state.round_number == 2
+        assert state.round_number == 1
 
     def test_non_keeper_cannot_set_prompt(self):
         keeper = UserFactory()

--- a/totem/rooms/tests/test_state_machine.py
+++ b/totem/rooms/tests/test_state_machine.py
@@ -407,7 +407,7 @@ class TestPassStick:
         state = apply_event(slug, keeper.slug, PassStickEvent(prompt="   "), 3, connected)
         assert state.turn_state == TurnState.PASSING
 
-    def test_keeper_can_skip_prompt_and_clear_round_message(self):
+    def test_prompt_clears_at_round_boundary(self):
         keeper = UserFactory()
         user1 = UserFactory()
         user2 = UserFactory()
@@ -420,32 +420,39 @@ class TestPassStick:
         apply_event(slug, user1.slug, PassStickEvent(), 3, connected)
         apply_event(slug, user2.slug, AcceptStickEvent(), 4, connected)
         apply_event(slug, user2.slug, PassStickEvent(), 5, connected)
-        apply_event(slug, keeper.slug, AcceptStickEvent(), 6, connected)
 
-        state = apply_event(slug, keeper.slug, PassStickEvent(), 7, connected)
+        # The stick returns to the keeper, so the prompt clears at the boundary.
+        state = apply_event(slug, keeper.slug, AcceptStickEvent(), 6, connected)
 
         assert state.round_number == 2
         assert state.round_message is None
 
-    def test_keeper_pass_empty_string_clears_round_message(self):
+    def test_keeper_pass_empty_prompt_leaves_start_prompt_intact(self):
         keeper = UserFactory()
         user1 = UserFactory()
-        user2 = UserFactory()
-        _, slug = _setup_room(keeper, [keeper, user1, user2])
-        connected = {keeper.slug, user1.slug, user2.slug}
+        _, slug = _setup_room(keeper, [keeper, user1])
+        connected = {keeper.slug, user1.slug}
+
+        apply_event(slug, keeper.slug, StartRoomEvent(prompt="Opening prompt"), 0, connected)
+
+        state = apply_event(slug, keeper.slug, PassStickEvent(prompt=""), 1, connected)
+
+        assert state.round_number == 1
+        assert state.round_message == "Opening prompt"
+
+    def test_keeper_pass_empty_prompt_leaves_midround_prompt_intact(self):
+        keeper = UserFactory()
+        user1 = UserFactory()
+        _, slug = _setup_room(keeper, [keeper, user1])
+        connected = {keeper.slug, user1.slug}
 
         apply_event(slug, keeper.slug, StartRoomEvent(), 0, connected)
-        apply_event(slug, keeper.slug, PassStickEvent(prompt="Round 2 prompt"), 1, connected)
-        apply_event(slug, user1.slug, AcceptStickEvent(), 2, connected)
-        apply_event(slug, user1.slug, PassStickEvent(), 3, connected)
-        apply_event(slug, user2.slug, AcceptStickEvent(), 4, connected)
-        apply_event(slug, user2.slug, PassStickEvent(), 5, connected)
-        apply_event(slug, keeper.slug, AcceptStickEvent(), 6, connected)
+        apply_event(slug, keeper.slug, SetPromptEvent(prompt="Mid-round prompt"), 1, connected)
 
-        state = apply_event(slug, keeper.slug, PassStickEvent(prompt=""), 7, connected)
+        state = apply_event(slug, keeper.slug, PassStickEvent(prompt=""), 2, connected)
 
-        assert state.round_number == 2
-        assert state.round_message is None
+        assert state.round_number == 1
+        assert state.round_message == "Mid-round prompt"
 
     def test_start_prompt_survives_first_pass(self):
         keeper = UserFactory()
@@ -514,6 +521,41 @@ class TestPassStick:
         state = apply_event(slug, keeper.slug, AcceptStickEvent(), 6, connected)
 
         assert state.round_number == 2
+
+    def test_solo_keeper_does_not_lose_prompt_or_overcount(self):
+        keeper = UserFactory()
+        _, slug = _setup_room(keeper, [keeper])
+        connected = {keeper.slug}
+
+        started = apply_event(slug, keeper.slug, StartRoomEvent(), 0, connected)
+        assert started.round_number == 1
+
+        passed = apply_event(slug, keeper.slug, PassStickEvent(prompt="Solo prompt"), 1, connected)
+        assert passed.round_number == 1
+        assert passed.round_message == "Solo prompt"
+
+        state = apply_event(slug, keeper.slug, AcceptStickEvent(), 2, connected)
+
+        assert state.round_number == 1
+        assert state.round_message == "Solo prompt"
+
+    def test_keeper_does_not_overcount_when_participant_disconnects(self):
+        keeper = UserFactory()
+        user1 = UserFactory()
+        _, slug = _setup_room(keeper, [keeper, user1])
+        all_connected = {keeper.slug, user1.slug}
+
+        apply_event(slug, keeper.slug, StartRoomEvent(), 0, all_connected)
+
+        # user1 disconnects while the keeper holds the stick, so the stick
+        # points back at the keeper.
+        passed = apply_event(slug, keeper.slug, PassStickEvent(prompt="Prompt"), 1, {keeper.slug})
+        assert passed.round_message == "Prompt"
+
+        state = apply_event(slug, keeper.slug, AcceptStickEvent(), 2, {keeper.slug})
+
+        assert state.round_number == 1
+        assert state.round_message == "Prompt"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Before, it incremented right when the keeper passed the Totem. This caused incorrect behavior when the prompt was set at the Start Session Event.