### PR TITLE
Overlapping Session Handle

### DIFF
--- a/totem/spaces/mobile_api/mobile_api.py
+++ b/totem/spaces/mobile_api/mobile_api.py
@@ -35,7 +35,7 @@ spaces_router = Router(tags=["spaces"])
 
 
 def _session_conflict_schema(session: Session, user: User, error: SessionTimeConflict) -> SessionConflictSchema:
-    conflicting_sessions = session.time_conflicts_for(user).select_related("space")
+    conflicting_sessions = Session.objects.time_conflicts_for(session, user).select_related("space")
     return SessionConflictSchema(
         message=str(error),
         conflicting_sessions=[session_detail_schema(conflict, user) for conflict in conflicting_sessions],
@@ -217,8 +217,14 @@ def rsvp_resolve_conflicts(request: HttpRequest, event_slug: str, payload: Resol
 
             conflicting_sessions = []
             if not user.is_staff:
+                conflicting_session_pks = list(
+                    Session.objects.time_conflicts_for(session, user).order_by().values_list("pk", flat=True)
+                )
                 conflicting_sessions = list(
-                    session.time_conflicts_for(user).select_for_update().select_related("space").order_by("pk")
+                    Session.objects.select_for_update(of=("self",))
+                    .select_related("space")
+                    .filter(pk__in=conflicting_session_pks)
+                    .order_by("pk")
                 )
             session.can_attend(user=user, excluding_time_conflicts=conflicting_sessions)
             for session_to_remove in conflicting_sessions:

--- a/totem/spaces/mobile_api/mobile_api.py
+++ b/totem/spaces/mobile_api/mobile_api.py
@@ -219,14 +219,10 @@ def rsvp_resolve_conflicts(request: HttpRequest, event_slug: str, payload: Resol
                 item.slug: item
                 for item in Session.objects.visible_to(user)
                 .filter(slug__in=submitted_slugs, attendees=user)
-                .with_overlap(session)
+                .overlapping(session)
                 .select_related("space__author")
                 .prefetch_related("attendees")
             }
-            if set(submitted_sessions) != submitted_slugs:
-                raise Http404
-            if not all(item.overlaps_session for item in submitted_sessions.values()):  # type: ignore[attr-defined]
-                raise AuthorizationError(message="Sessions do not conflict")
 
             current_conflict_slugs = (
                 list(Session.objects.time_conflicts_for(session, user).values_list("slug", flat=True))

--- a/totem/spaces/mobile_api/mobile_api.py
+++ b/totem/spaces/mobile_api/mobile_api.py
@@ -224,14 +224,10 @@ def rsvp_resolve_conflicts(request: HttpRequest, event_slug: str, payload: Resol
                 .prefetch_related("attendees")
             }
 
-            current_conflict_slugs = (
-                list(Session.objects.time_conflicts_for(session, user).values_list("slug", flat=True))
-                if not user.is_staff
-                else []
-            )
+            detected_conflicts = list(Session.objects.time_conflicts_for(session, user)) if not user.is_staff else []
+            current_conflict_slugs = [conflict.slug for conflict in detected_conflicts]
             if set(current_conflict_slugs) - submitted_slugs:
-                current_conflicts = list(Session.objects.time_conflicts_for(session, user))
-                return Status(409, _session_conflict_schema(current_conflicts, user))
+                return Status(409, _session_conflict_schema(detected_conflicts, user))
 
             session.can_attend(user=user, check_time_conflicts=False)
             current_conflicts = [submitted_sessions[slug] for slug in current_conflict_slugs]

--- a/totem/spaces/mobile_api/mobile_api.py
+++ b/totem/spaces/mobile_api/mobile_api.py
@@ -197,37 +197,27 @@ def rsvp_resolve_conflicts(request: HttpRequest, event_slug: str, payload: Resol
 
     try:
         with transaction.atomic():
-            locked_sessions = {
+            submitted_slugs = set(payload.conflicting_session_slugs)
+            submitted_sessions = {
                 item.slug: item
-                for item in Session.objects.select_for_update()
-                .select_related("space")
-                .filter(slug__in=[event_slug, payload.conflicting_session_slug])
-                .order_by("pk")
+                for item in Session.objects.visible_to(user).select_related("space").filter(slug__in=submitted_slugs)
             }
-            session = locked_sessions.get(event_slug)
-            conflicting_session = locked_sessions.get(payload.conflicting_session_slug)
-            if session is None or conflicting_session is None:
+            if set(submitted_sessions) != submitted_slugs:
                 raise Http404
-            if not conflicting_session.can_view(user):
-                raise Http404
-            if not conflicting_session.attendees.filter(pk=user.pk).exists():
-                raise Http404
-            if not session.overlaps(conflicting_session):
-                raise AuthorizationError(message="Sessions do not conflict")
+            for submitted_slug in submitted_slugs:
+                submitted_session = submitted_sessions[submitted_slug]
+                if not submitted_session.attendees.filter(pk=user.pk).exists():
+                    raise Http404
+                if not session.overlaps(submitted_session):
+                    raise AuthorizationError(message="Sessions do not conflict")
 
-            conflicting_sessions = []
-            if not user.is_staff:
-                conflicting_session_pks = list(
-                    Session.objects.time_conflicts_for(session, user).order_by().values_list("pk", flat=True)
-                )
-                conflicting_sessions = list(
-                    Session.objects.select_for_update(of=("self",))
-                    .select_related("space")
-                    .filter(pk__in=conflicting_session_pks)
-                    .order_by("pk")
-                )
-            session.can_attend(user=user, excluding_time_conflicts=conflicting_sessions)
-            for session_to_remove in conflicting_sessions:
+            current_conflicts = list(Session.objects.time_conflicts_for(session, user)) if not user.is_staff else []
+            current_conflict_slugs = {conflict.slug for conflict in current_conflicts}
+            if current_conflict_slugs - submitted_slugs:
+                return Status(409, _session_conflict_schema(session, user, SessionTimeConflict(current_conflicts[0])))
+
+            session.can_attend(user=user, excluding_time_conflicts=current_conflicts)
+            for session_to_remove in current_conflicts:
                 session_to_remove.remove_attendee(user)
             session.add_attendee(user)
             session.space.subscribe(user)

--- a/totem/spaces/mobile_api/mobile_api.py
+++ b/totem/spaces/mobile_api/mobile_api.py
@@ -199,14 +199,18 @@ def rsvp_switch(request: HttpRequest, event_slug: str, payload: SwitchSessionSch
             conflicting_session = locked_sessions.get(payload.conflicting_session_slug)
             if session is None or conflicting_session is None:
                 raise Http404
+            if not conflicting_session.can_view(user):
+                raise Http404
             if not conflicting_session.attendees.filter(pk=user.pk).exists():
                 raise Http404
             if not session.overlaps(conflicting_session):
                 raise AuthorizationError(message="Sessions do not conflict")
 
-            conflicting_sessions = list(
-                session.time_conflicts_for(user).select_for_update().select_related("space").order_by("pk")
-            )
+            conflicting_sessions = []
+            if not user.is_staff:
+                conflicting_sessions = list(
+                    session.time_conflicts_for(user).select_for_update().select_related("space").order_by("pk")
+                )
             session.can_attend(user=user, excluding_time_conflicts=conflicting_sessions)
             for conflicting_session in conflicting_sessions:
                 conflicting_session.remove_attendee(user)

--- a/totem/spaces/mobile_api/mobile_api.py
+++ b/totem/spaces/mobile_api/mobile_api.py
@@ -208,8 +208,12 @@ def rsvp_resolve_conflicts(request: HttpRequest, event_slug: str, payload: Resol
                 submitted_session = submitted_sessions[submitted_slug]
                 if not submitted_session.attendees.filter(pk=user.pk).exists():
                     raise Http404
-                if not session.overlaps(submitted_session):
-                    raise AuthorizationError(message="Sessions do not conflict")
+
+            overlapping_submitted_slugs = set(
+                Session.objects.overlapping(session).filter(slug__in=submitted_slugs).values_list("slug", flat=True)
+            )
+            if overlapping_submitted_slugs != submitted_slugs:
+                raise AuthorizationError(message="Sessions do not conflict")
 
             current_conflicts = list(Session.objects.time_conflicts_for(session, user)) if not user.is_staff else []
             current_conflict_slugs = {conflict.slug for conflict in current_conflicts}

--- a/totem/spaces/mobile_api/mobile_api.py
+++ b/totem/spaces/mobile_api/mobile_api.py
@@ -14,12 +14,12 @@ from totem.spaces.mobile_api.mobile_filters import (
 )
 from totem.spaces.mobile_api.mobile_schemas import (
     MobileSpaceDetailSchema,
+    ResolveConflictsSchema,
     SessionConflictSchema,
     SessionDetailSchema,
     SessionFeedbackSchema,
     SpaceSchema,
     SummarySpacesSchema,
-    SwitchSessionSchema,
 )
 from totem.spaces.models import (
     Session,
@@ -184,12 +184,12 @@ def rsvp_confirm(request: HttpRequest, event_slug: str):
 
 
 @spaces_router.post(
-    "/rsvp/{event_slug}/switch",
+    "/rsvp/{event_slug}/resolve-conflicts",
     response={200: SessionDetailSchema, 409: SessionConflictSchema},
     tags=["spaces"],
-    url_name="rsvp_switch",
+    url_name="rsvp_resolve_conflicts",
 )
-def rsvp_switch(request: HttpRequest, event_slug: str, payload: SwitchSessionSchema):
+def rsvp_resolve_conflicts(request: HttpRequest, event_slug: str, payload: ResolveConflictsSchema):
     user: User = request.user  # type: ignore
     session = get_object_or_404(Session, slug=event_slug)
     if not session.can_view(user):

--- a/totem/spaces/mobile_api/mobile_api.py
+++ b/totem/spaces/mobile_api/mobile_api.py
@@ -204,8 +204,12 @@ def rsvp_switch(request: HttpRequest, event_slug: str, payload: SwitchSessionSch
             if not session.overlaps(conflicting_session):
                 raise AuthorizationError(message="Sessions do not conflict")
 
-            session.can_attend(user=user, excluding_time_conflict=conflicting_session)
-            conflicting_session.remove_attendee(user)
+            conflicting_sessions = list(
+                session.time_conflicts_for(user).select_for_update().select_related("space").order_by("pk")
+            )
+            session.can_attend(user=user, excluding_time_conflicts=conflicting_sessions)
+            for conflicting_session in conflicting_sessions:
+                conflicting_session.remove_attendee(user)
             session.add_attendee(user)
             session.space.subscribe(user)
     except SessionTimeConflict as e:

--- a/totem/spaces/mobile_api/mobile_api.py
+++ b/totem/spaces/mobile_api/mobile_api.py
@@ -240,7 +240,8 @@ def rsvp_resolve_conflicts(request: HttpRequest, event_slug: str, payload: Resol
             current_conflicts = [submitted_sessions[slug] for slug in current_conflict_slugs]
             for session_to_remove in current_conflicts:
                 session_to_remove.remove_attendee(user)
-            session.add_attendee(user, prevalidated=True)
+            if not session.add_attendee(user, prevalidated=True):
+                raise SessionException("Unable to save your spot")
             session.space.subscribe(user)
     except SessionTimeConflict as e:
         return Status(409, _session_conflict_schema(e.conflicting_sessions, user))

--- a/totem/spaces/mobile_api/mobile_api.py
+++ b/totem/spaces/mobile_api/mobile_api.py
@@ -221,8 +221,8 @@ def rsvp_switch(request: HttpRequest, event_slug: str, payload: SwitchSessionSch
                     session.time_conflicts_for(user).select_for_update().select_related("space").order_by("pk")
                 )
             session.can_attend(user=user, excluding_time_conflicts=conflicting_sessions)
-            for conflicting_session in conflicting_sessions:
-                conflicting_session.remove_attendee(user)
+            for session_to_remove in conflicting_sessions:
+                session_to_remove.remove_attendee(user)
             session.add_attendee(user)
             session.space.subscribe(user)
     except SessionTimeConflict as e:

--- a/totem/spaces/mobile_api/mobile_api.py
+++ b/totem/spaces/mobile_api/mobile_api.py
@@ -14,6 +14,7 @@ from totem.spaces.mobile_api.mobile_filters import (
 )
 from totem.spaces.mobile_api.mobile_schemas import (
     MobileSpaceDetailSchema,
+    SessionConflictSchema,
     SessionDetailSchema,
     SessionFeedbackSchema,
     SpaceSchema,
@@ -31,6 +32,14 @@ from totem.spaces.models import (
 from totem.users.models import User
 
 spaces_router = Router(tags=["spaces"])
+
+
+def _session_conflict_schema(session: Session, user: User, error: SessionTimeConflict) -> SessionConflictSchema:
+    conflicting_sessions = session.time_conflicts_for(user).select_related("space")
+    return SessionConflictSchema(
+        message=str(error),
+        conflicting_sessions=[session_detail_schema(conflict, user) for conflict in conflicting_sessions],
+    )
 
 
 @spaces_router.post("/subscribe/{space_slug}", response={200: bool}, url_name="spaces_subscribe")
@@ -154,7 +163,7 @@ def get_spaces_summary(request: HttpRequest):
 
 @spaces_router.post(
     "/rsvp/{event_slug}",
-    response={200: SessionDetailSchema, 409: SessionDetailSchema},
+    response={200: SessionDetailSchema, 409: SessionConflictSchema},
     tags=["spaces"],
     url_name="rsvp_confirm",
 )
@@ -168,7 +177,7 @@ def rsvp_confirm(request: HttpRequest, event_slug: str):
             session.add_attendee(user)
             session.space.subscribe(user)
     except SessionTimeConflict as e:
-        return Status(409, session_detail_schema(e.conflicting_session, user))
+        return Status(409, _session_conflict_schema(session, user, e))
     except SessionException as e:
         raise AuthorizationError(message=str(e))
     return session_detail_schema(session, user)
@@ -176,7 +185,7 @@ def rsvp_confirm(request: HttpRequest, event_slug: str):
 
 @spaces_router.post(
     "/rsvp/{event_slug}/switch",
-    response={200: SessionDetailSchema, 409: SessionDetailSchema},
+    response={200: SessionDetailSchema, 409: SessionConflictSchema},
     tags=["spaces"],
     url_name="rsvp_switch",
 )
@@ -217,7 +226,7 @@ def rsvp_switch(request: HttpRequest, event_slug: str, payload: SwitchSessionSch
             session.add_attendee(user)
             session.space.subscribe(user)
     except SessionTimeConflict as e:
-        return Status(409, session_detail_schema(e.conflicting_session, user))
+        return Status(409, _session_conflict_schema(session, user, e))
     except SessionException as e:
         raise AuthorizationError(message=str(e))
     return session_detail_schema(session, user)

--- a/totem/spaces/mobile_api/mobile_api.py
+++ b/totem/spaces/mobile_api/mobile_api.py
@@ -1,5 +1,5 @@
 from django.db import transaction
-from django.db.models import Prefetch
+from django.db.models import Prefetch, prefetch_related_objects
 from django.http import Http404, HttpRequest
 from django.shortcuts import get_object_or_404
 from ninja import Query, Router, Status
@@ -34,10 +34,23 @@ from totem.users.models import User
 spaces_router = Router(tags=["spaces"])
 
 
-def _session_conflict_schema(session: Session, user: User, error: SessionTimeConflict) -> SessionConflictSchema:
-    conflicting_sessions = Session.objects.time_conflicts_for(session, user).select_related("space")
+def _prefetch_session_detail_relations(sessions: list[Session], user: User) -> None:
+    upcoming_sessions = upcoming_sessions_queryset(user).prefetch_related("joined")
+    prefetch_related_objects(
+        sessions,
+        "attendees",
+        "joined",
+        "space__author__sessions_joined",
+        "space__categories",
+        "space__subscribed",
+        Prefetch("space__sessions", queryset=upcoming_sessions, to_attr="upcoming_sessions"),
+    )
+
+
+def _session_conflict_schema(conflicting_sessions: list[Session], user: User) -> SessionConflictSchema:
+    _prefetch_session_detail_relations(conflicting_sessions, user)
     return SessionConflictSchema(
-        message=str(error),
+        message=SessionTimeConflict.message,
         conflicting_sessions=[session_detail_schema(conflict, user) for conflict in conflicting_sessions],
     )
 
@@ -177,7 +190,7 @@ def rsvp_confirm(request: HttpRequest, event_slug: str):
             session.add_attendee(user)
             session.space.subscribe(user)
     except SessionTimeConflict as e:
-        return Status(409, _session_conflict_schema(session, user, e))
+        return Status(409, _session_conflict_schema(e.conflicting_sessions, user))
     except SessionException as e:
         raise AuthorizationError(message=str(e))
     return session_detail_schema(session, user)
@@ -191,7 +204,10 @@ def rsvp_confirm(request: HttpRequest, event_slug: str):
 )
 def rsvp_resolve_conflicts(request: HttpRequest, event_slug: str, payload: ResolveConflictsSchema):
     user: User = request.user  # type: ignore
-    session = get_object_or_404(Session, slug=event_slug)
+    session = get_object_or_404(
+        Session.objects.select_related("space", "space__author", "room").prefetch_related("attendees"),
+        slug=event_slug,
+    )
     if not session.can_view(user):
         raise Http404
 
@@ -200,35 +216,37 @@ def rsvp_resolve_conflicts(request: HttpRequest, event_slug: str, payload: Resol
             submitted_slugs = set(payload.conflicting_session_slugs)
             submitted_sessions = {
                 item.slug: item
-                for item in Session.objects.visible_to(user).select_related("space").filter(slug__in=submitted_slugs)
+                for item in Session.objects.visible_to(user)
+                .filter(slug__in=submitted_slugs, attendees=user)
+                .with_overlap(session)
+                .select_related("space__author")
+                .prefetch_related("attendees")
             }
             if set(submitted_sessions) != submitted_slugs:
                 raise Http404
-            for submitted_slug in submitted_slugs:
-                submitted_session = submitted_sessions[submitted_slug]
-                if not submitted_session.attendees.filter(pk=user.pk).exists():
-                    raise Http404
-
-            overlapping_submitted_slugs = set(
-                Session.objects.overlapping(session).filter(slug__in=submitted_slugs).values_list("slug", flat=True)
-            )
-            if overlapping_submitted_slugs != submitted_slugs:
+            if not all(item.overlaps_session for item in submitted_sessions.values()):  # type: ignore[attr-defined]
                 raise AuthorizationError(message="Sessions do not conflict")
 
-            current_conflicts = list(Session.objects.time_conflicts_for(session, user)) if not user.is_staff else []
-            current_conflict_slugs = {conflict.slug for conflict in current_conflicts}
-            if current_conflict_slugs - submitted_slugs:
-                return Status(409, _session_conflict_schema(session, user, SessionTimeConflict(current_conflicts[0])))
+            current_conflict_slugs = (
+                list(Session.objects.time_conflicts_for(session, user).values_list("slug", flat=True))
+                if not user.is_staff
+                else []
+            )
+            if set(current_conflict_slugs) - submitted_slugs:
+                current_conflicts = list(Session.objects.time_conflicts_for(session, user))
+                return Status(409, _session_conflict_schema(current_conflicts, user))
 
-            session.can_attend(user=user, excluding_time_conflicts=current_conflicts)
+            session.can_attend(user=user, check_time_conflicts=False)
+            current_conflicts = [submitted_sessions[slug] for slug in current_conflict_slugs]
             for session_to_remove in current_conflicts:
                 session_to_remove.remove_attendee(user)
-            session.add_attendee(user)
+            session.add_attendee(user, prevalidated=True)
             session.space.subscribe(user)
     except SessionTimeConflict as e:
-        return Status(409, _session_conflict_schema(session, user, e))
+        return Status(409, _session_conflict_schema(e.conflicting_sessions, user))
     except SessionException as e:
         raise AuthorizationError(message=str(e))
+    _prefetch_session_detail_relations([session], user)
     return session_detail_schema(session, user)
 
 

--- a/totem/spaces/mobile_api/mobile_api.py
+++ b/totem/spaces/mobile_api/mobile_api.py
@@ -187,7 +187,8 @@ def rsvp_confirm(request: HttpRequest, event_slug: str):
         raise Http404
     try:
         with transaction.atomic():
-            session.add_attendee(user)
+            if not session.add_attendee(user):
+                raise SessionException("Unable to save your spot")
             session.space.subscribe(user)
     except SessionTimeConflict as e:
         return Status(409, _session_conflict_schema(e.conflicting_sessions, user))
@@ -243,8 +244,6 @@ def rsvp_resolve_conflicts(request: HttpRequest, event_slug: str, payload: Resol
             if not session.add_attendee(user, prevalidated=True):
                 raise SessionException("Unable to save your spot")
             session.space.subscribe(user)
-    except SessionTimeConflict as e:
-        return Status(409, _session_conflict_schema(e.conflicting_sessions, user))
     except SessionException as e:
         raise AuthorizationError(message=str(e))
     _prefetch_session_detail_relations([session], user)

--- a/totem/spaces/mobile_api/mobile_api.py
+++ b/totem/spaces/mobile_api/mobile_api.py
@@ -18,12 +18,14 @@ from totem.spaces.mobile_api.mobile_schemas import (
     SessionFeedbackSchema,
     SpaceSchema,
     SummarySpacesSchema,
+    SwitchSessionSchema,
 )
 from totem.spaces.models import (
     Session,
     SessionException,
     SessionFeedback,
     SessionFeedbackOptions,
+    SessionTimeConflict,
     Space,
 )
 from totem.users.models import User
@@ -152,22 +154,65 @@ def get_spaces_summary(request: HttpRequest):
 
 @spaces_router.post(
     "/rsvp/{event_slug}",
-    response={200: SessionDetailSchema},
+    response={200: SessionDetailSchema, 409: SessionDetailSchema},
     tags=["spaces"],
     url_name="rsvp_confirm",
 )
 def rsvp_confirm(request: HttpRequest, event_slug: str):
     user: User = request.user  # type: ignore
-    event = get_object_or_404(Session, slug=event_slug)
-    if not event.can_view(user):
+    session = get_object_or_404(Session, slug=event_slug)
+    if not session.can_view(user):
         raise Http404
     try:
         with transaction.atomic():
-            event.add_attendee(user)
-            event.space.subscribe(user)
+            session.add_attendee(user)
+            session.space.subscribe(user)
+    except SessionTimeConflict as e:
+        return Status(409, session_detail_schema(e.conflicting_session, user))
     except SessionException as e:
         raise AuthorizationError(message=str(e))
-    return session_detail_schema(event, user)
+    return session_detail_schema(session, user)
+
+
+@spaces_router.post(
+    "/rsvp/{event_slug}/switch",
+    response={200: SessionDetailSchema, 409: SessionDetailSchema},
+    tags=["spaces"],
+    url_name="rsvp_switch",
+)
+def rsvp_switch(request: HttpRequest, event_slug: str, payload: SwitchSessionSchema):
+    user: User = request.user  # type: ignore
+    session = get_object_or_404(Session, slug=event_slug)
+    if not session.can_view(user):
+        raise Http404
+
+    try:
+        with transaction.atomic():
+            locked_sessions = {
+                item.slug: item
+                for item in Session.objects.select_for_update()
+                .select_related("space")
+                .filter(slug__in=[event_slug, payload.conflicting_session_slug])
+                .order_by("pk")
+            }
+            session = locked_sessions.get(event_slug)
+            conflicting_session = locked_sessions.get(payload.conflicting_session_slug)
+            if session is None or conflicting_session is None:
+                raise Http404
+            if not conflicting_session.attendees.filter(pk=user.pk).exists():
+                raise Http404
+            if not session.overlaps(conflicting_session):
+                raise AuthorizationError(message="Sessions do not conflict")
+
+            session.can_attend(user=user, excluding_time_conflict=conflicting_session)
+            conflicting_session.remove_attendee(user)
+            session.add_attendee(user)
+            session.space.subscribe(user)
+    except SessionTimeConflict as e:
+        return Status(409, session_detail_schema(e.conflicting_session, user))
+    except SessionException as e:
+        raise AuthorizationError(message=str(e))
+    return session_detail_schema(session, user)
 
 
 @spaces_router.delete(
@@ -178,11 +223,11 @@ def rsvp_confirm(request: HttpRequest, event_slug: str):
 )
 def rsvp_cancel(request: HttpRequest, event_slug: str):
     user: User = request.user  # type: ignore
-    event = get_object_or_404(Session, slug=event_slug)
-    if not event.can_view(user):
+    session = get_object_or_404(Session, slug=event_slug)
+    if not session.can_view(user):
         raise Http404
     try:
-        event.remove_attendee(user)
+        session.remove_attendee(user)
     except SessionException as e:
         raise AuthorizationError(message=str(e))
-    return session_detail_schema(event, user)
+    return session_detail_schema(session, user)

--- a/totem/spaces/mobile_api/mobile_filters.py
+++ b/totem/spaces/mobile_api/mobile_filters.py
@@ -108,7 +108,7 @@ def next_session_schema(next_session: Session, user: User):
 
 def space_detail_schema(space: Space, user: User):
     if hasattr(space, "_prefetched_objects_cache") and "categories" in space._prefetched_objects_cache:
-        category = next(iter(space.categories.all()), None)
+        category = min(space.categories.all(), key=lambda item: item.pk, default=None)
     else:
         category = space.categories.first()
     category_name = category.name if category else None

--- a/totem/spaces/mobile_api/mobile_filters.py
+++ b/totem/spaces/mobile_api/mobile_filters.py
@@ -53,7 +53,7 @@ def session_detail_schema(session: Session, user: User):
         subscribed = None
     ended = session.ended()
 
-    if hasattr(space, "_prefetched_objects_cache") and "attendees" in space._prefetched_objects_cache:
+    if hasattr(session, "_prefetched_objects_cache") and "attendees" in session._prefetched_objects_cache:
         attending = any(attendee.pk == user.pk for attendee in session.attendees.all())
     else:
         attending = session.attendees.filter(pk=user.pk).exists()
@@ -107,7 +107,10 @@ def next_session_schema(next_session: Session, user: User):
 
 
 def space_detail_schema(space: Space, user: User):
-    category = space.categories.first()
+    if hasattr(space, "_prefetched_objects_cache") and "categories" in space._prefetched_objects_cache:
+        category = next(iter(space.categories.all()), None)
+    else:
+        category = space.categories.first()
     category_name = category.name if category else None
 
     if hasattr(space, "upcoming_sessions"):

--- a/totem/spaces/mobile_api/mobile_schemas.py
+++ b/totem/spaces/mobile_api/mobile_schemas.py
@@ -106,4 +106,4 @@ class SessionFeedbackSchema(Schema):
 
 
 class ResolveConflictsSchema(Schema):
-    conflicting_session_slug: str
+    conflicting_session_slugs: list[str]

--- a/totem/spaces/mobile_api/mobile_schemas.py
+++ b/totem/spaces/mobile_api/mobile_schemas.py
@@ -105,5 +105,5 @@ class SessionFeedbackSchema(Schema):
     message: str | None = None
 
 
-class SwitchSessionSchema(Schema):
+class ResolveConflictsSchema(Schema):
     conflicting_session_slug: str

--- a/totem/spaces/mobile_api/mobile_schemas.py
+++ b/totem/spaces/mobile_api/mobile_schemas.py
@@ -98,3 +98,7 @@ class SummarySpacesSchema(Schema):
 class SessionFeedbackSchema(Schema):
     feedback: SessionFeedbackOptions
     message: str | None = None
+
+
+class SwitchSessionSchema(Schema):
+    conflicting_session_slug: str

--- a/totem/spaces/mobile_api/mobile_schemas.py
+++ b/totem/spaces/mobile_api/mobile_schemas.py
@@ -89,6 +89,11 @@ class SessionDetailSchema(Schema):
     meeting_provider: MeetingProviderEnum
 
 
+class SessionConflictSchema(Schema):
+    message: str
+    conflicting_sessions: list[SessionDetailSchema]
+
+
 class SummarySpacesSchema(Schema):
     upcoming: list[SessionDetailSchema]
     for_you: list[MobileSpaceDetailSchema]

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -120,6 +120,22 @@ class SessionQuerySet(models.QuerySet["Session"]):
             )
         )
 
+    def time_conflicts_for(self, session: "Session", user: "User") -> "SessionQuerySet":
+        """Visible, removable sessions this user attends that overlap ``session``."""
+        now = timezone.now()
+        return (
+            self.visible_to(user)
+            .not_ended()
+            .filter(
+                attendees=user,
+                start__gte=now,
+                start__lt=session.end(),
+                session_end_time__gt=session.start,
+            )
+            .exclude(pk=session.pk)
+            .order_by("start", "pk")
+        )
+
 
 class SessionState(Enum):
     OPEN = "OPEN"
@@ -313,27 +329,9 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
         """Whether this session and another occupy any of the same time."""
         return self.start < other.end() and self.end() > other.start
 
-    def time_conflicts_for(self, user: "User") -> "SessionQuerySet":
-        """Return visible sessions this user is attending that overlap this one."""
-        sessions = (
-            Session.objects.filter(
-                attendees=user,
-                cancelled=False,
-                ended_at__isnull=True,
-                start__gte=timezone.now(),
-                start__lt=self.end(),
-            )
-            .annotate(session_end_time=SESSION_END_TIME)
-            .filter(session_end_time__gt=self.start)
-            .exclude(pk=self.pk)
-        )
-        if not user.is_staff:
-            sessions = sessions.filter(space__published=True)
-        return sessions.order_by("start", "pk")
-
     def time_conflict_for(self, user: "User", excluding: "list[Session] | None" = None) -> "Session | None":
         """Return the first session this user is attending that overlaps this one."""
-        sessions = self.time_conflicts_for(user)
+        sessions = Session.objects.time_conflicts_for(self, user)
         if excluding:
             sessions = sessions.exclude(pk__in=[session.pk for session in excluding])
         return sessions.first()

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -320,6 +320,7 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
                 attendees=user,
                 cancelled=False,
                 ended_at__isnull=True,
+                start__gte=timezone.now(),
                 start__lt=self.end(),
             )
             .annotate(session_end_time=SESSION_END_TIME)

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -346,17 +346,18 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
                 raise SessionException("You are already attending this session")
             if user and self.user_is_banned(user):
                 raise SessionException("You cannot attend this session")
-            if not (user and user.is_staff):
-                if not self.space.published:
-                    raise SessionException("Session is not available for signup")
-                if not self.open:
-                    raise SessionException("Session is not available for signup")
-                if self.cancelled:
-                    raise SessionException("Session was cancelled")
-                if self.started():
-                    raise SessionException("Session has already started")
-                if self.seats_left() <= 0:
-                    raise SessionException("There are no spots left")
+            if user and user.is_staff:
+                return True
+            if not self.space.published:
+                raise SessionException("Session is not available for signup")
+            if not self.open:
+                raise SessionException("Session is not available for signup")
+            if self.cancelled:
+                raise SessionException("Session was cancelled")
+            if self.started():
+                raise SessionException("Session has already started")
+            if self.seats_left() <= 0:
+                raise SessionException("There are no spots left")
             if user:
                 conflicting_session = self.time_conflict_for(user, excluding=excluding_time_conflicts)
                 if conflicting_session is not None:

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -341,9 +341,9 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
     def can_attend(
         self,
         user: "User | None" = None,
-        silent=False,
+        silent: bool = False,
         excluding_time_conflicts: "list[Session] | None" = None,
-    ):
+    ) -> bool:
         try:
             if user and user in self.attendees.all():
                 raise SessionException("You are already attending this session")

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -388,7 +388,7 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
             return SessionState.JOINABLE
         return SessionState.CLOSED
 
-    def add_attendee(self, user: "User", *, prevalidated: bool = False) -> None:
+    def add_attendee(self, user: "User", *, prevalidated: bool = False) -> bool:
         # checks if the user can attend and adds them to the attendees list, throws an exception if they can't
         if prevalidated or self.can_attend(user=user):
             self.attendees.add(user)
@@ -404,12 +404,13 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
                 # If the email was blocked, remove the user from the session and space
                 self.attendees.remove(user)
                 self.space.unsubscribe(user)
-                return
+                return False
             if not self.space.author == user:
                 notify_slack(
                     f"✅ New session attendee: {self._get_slack_attendee_message(user)}",
                     email_to_mention=self.space.author.email,
                 )
+            return True
 
     def started(self):
         return self.start < timezone.now()

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -125,12 +125,19 @@ class SessionQuerySet(models.QuerySet["Session"]):
         now = timezone.now()
         return self.visible_to(user).not_ended().filter(attendees=user, start__gte=now)
 
+    def with_overlap(self, session: "Session") -> "SessionQuerySet":
+        """Annotate whether each session's half-open interval overlaps ``session``."""
+        return self.annotate(
+            session_end_time=SESSION_END_TIME,
+            overlaps_session=models.Q(
+                start__lt=session.end(),
+                session_end_time__gt=session.start,
+            ),
+        )
+
     def overlapping(self, session: "Session") -> "SessionQuerySet":
         """Sessions whose half-open time interval overlaps ``session``."""
-        return self.annotate(session_end_time=SESSION_END_TIME).filter(
-            start__lt=session.end(),
-            session_end_time__gt=session.start,
-        )
+        return self.with_overlap(session).filter(overlaps_session=True)
 
     def time_conflicts_for(self, session: "Session", user: "User") -> "SessionQuerySet":
         """Visible, removable sessions this user attends that overlap ``session``."""
@@ -327,16 +334,21 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
 
     def time_conflict_for(self, user: "User", excluding: "list[Session] | None" = None) -> "Session | None":
         """Return the first session this user is attending that overlaps this one."""
+        return self.time_conflicts_for(user, excluding=excluding).first()
+
+    def time_conflicts_for(self, user: "User", excluding: "list[Session] | None" = None) -> "SessionQuerySet":
+        """Return sessions this user is attending that overlap this one."""
         sessions = Session.objects.time_conflicts_for(self, user)
         if excluding:
             sessions = sessions.exclude(pk__in=[session.pk for session in excluding])
-        return sessions.first()
+        return sessions
 
     def can_attend(
         self,
         user: "User | None" = None,
         silent: bool = False,
         excluding_time_conflicts: "list[Session] | None" = None,
+        check_time_conflicts: bool = True,
     ) -> bool:
         try:
             if user and user in self.attendees.all():
@@ -355,10 +367,10 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
                 raise SessionException("Session has already started")
             if self.seats_left() <= 0:
                 raise SessionException("There are no spots left")
-            if user:
-                conflicting_session = self.time_conflict_for(user, excluding=excluding_time_conflicts)
-                if conflicting_session is not None:
-                    raise SessionTimeConflict(conflicting_session)
+            if user and check_time_conflicts:
+                conflicting_sessions = list(self.time_conflicts_for(user, excluding=excluding_time_conflicts))
+                if conflicting_sessions:
+                    raise SessionTimeConflict(conflicting_sessions)
             return True
         except SessionException as e:
             if silent:
@@ -376,9 +388,9 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
             return SessionState.JOINABLE
         return SessionState.CLOSED
 
-    def add_attendee(self, user):
+    def add_attendee(self, user: "User", *, prevalidated: bool = False) -> None:
         # checks if the user can attend and adds them to the attendees list, throws an exception if they can't
-        if self.can_attend(user=user):
+        if prevalidated or self.can_attend(user=user):
             self.attendees.add(user)
             try:
                 if self.notified and self.can_join(user):
@@ -570,9 +582,11 @@ class SessionException(Exception):
 
 
 class SessionTimeConflict(SessionException):
-    def __init__(self, conflicting_session: Session):
-        self.conflicting_session = conflicting_session
-        super().__init__("This session conflicts with one or more sessions you are attending")
+    message = "This session conflicts with one or more sessions you are attending"
+
+    def __init__(self, conflicting_sessions: list[Session]):
+        self.conflicting_sessions = conflicting_sessions
+        super().__init__(self.message)
 
 
 class SessionFeedbackOptions(models.TextChoices):

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -332,22 +332,14 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
         """Attendees, excluding users banned from this session's room."""
         return self._exclude_banned_users(self.attendees.all())
 
-    def time_conflict_for(self, user: "User", excluding: "list[Session] | None" = None) -> "Session | None":
-        """Return the first session this user is attending that overlaps this one."""
-        return self.time_conflicts_for(user, excluding=excluding).first()
-
-    def time_conflicts_for(self, user: "User", excluding: "list[Session] | None" = None) -> "SessionQuerySet":
+    def time_conflicts_for(self, user: "User") -> "SessionQuerySet":
         """Return sessions this user is attending that overlap this one."""
-        sessions = Session.objects.time_conflicts_for(self, user)
-        if excluding:
-            sessions = sessions.exclude(pk__in=[session.pk for session in excluding])
-        return sessions
+        return Session.objects.time_conflicts_for(self, user)
 
     def can_attend(
         self,
         user: "User | None" = None,
         silent: bool = False,
-        excluding_time_conflicts: "list[Session] | None" = None,
         check_time_conflicts: bool = True,
     ) -> bool:
         try:
@@ -368,7 +360,7 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
             if self.seats_left() <= 0:
                 raise SessionException("There are no spots left")
             if user and check_time_conflicts:
-                conflicting_sessions = list(self.time_conflicts_for(user, excluding=excluding_time_conflicts))
+                conflicting_sessions = list(self.time_conflicts_for(user))
                 if conflicting_sessions:
                     raise SessionTimeConflict(conflicting_sessions)
             return True
@@ -411,6 +403,7 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
                     email_to_mention=self.space.author.email,
                 )
             return True
+        return False
 
     def started(self):
         return self.start < timezone.now()

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -578,7 +578,7 @@ class SessionException(Exception):
 class SessionTimeConflict(SessionException):
     def __init__(self, conflicting_session: Session):
         self.conflicting_session = conflicting_session
-        super().__init__("This session conflicts with another session you are attending")
+        super().__init__("This session conflicts with one or more sessions you are attending")
 
 
 class SessionFeedbackOptions(models.TextChoices):

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -314,8 +314,8 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
         return self.start < other.end() and self.end() > other.start
 
     def time_conflicts_for(self, user: "User") -> "SessionQuerySet":
-        """Return sessions this user is attending that overlap this one."""
-        return (
+        """Return visible sessions this user is attending that overlap this one."""
+        sessions = (
             Session.objects.filter(
                 attendees=user,
                 cancelled=False,
@@ -325,8 +325,10 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
             .annotate(session_end_time=SESSION_END_TIME)
             .filter(session_end_time__gt=self.start)
             .exclude(pk=self.pk)
-            .order_by("start", "pk")
         )
+        if not user.is_staff:
+            sessions = sessions.filter(space__published=True)
+        return sessions.order_by("start", "pk")
 
     def time_conflict_for(self, user: "User", excluding: "list[Session] | None" = None) -> "Session | None":
         """Return the first session this user is attending that overlaps this one."""

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -309,24 +309,54 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
         """Attendees, excluding users banned from this session's room."""
         return self._exclude_banned_users(self.attendees.all())
 
-    def can_attend(self, user: "User | None" = None, silent=False):
+    def overlaps(self, other: "Session") -> bool:
+        """Whether this session and another occupy any of the same time."""
+        return self.start < other.end() and self.end() > other.start
+
+    def time_conflict_for(self, user: "User", excluding: "Session | None" = None) -> "Session | None":
+        """Return the first session this user is attending that overlaps this one."""
+        sessions = (
+            Session.objects.filter(
+                attendees=user,
+                cancelled=False,
+                ended_at__isnull=True,
+                start__lt=self.end(),
+            )
+            .annotate(session_end_time=SESSION_END_TIME)
+            .filter(session_end_time__gt=self.start)
+            .exclude(pk=self.pk)
+            .order_by("start", "pk")
+        )
+        if excluding is not None:
+            sessions = sessions.exclude(pk=excluding.pk)
+        return sessions.first()
+
+    def can_attend(
+        self,
+        user: "User | None" = None,
+        silent=False,
+        excluding_time_conflict: "Session | None" = None,
+    ):
         try:
             if user and user in self.attendees.all():
                 raise SessionException("You are already attending this session")
             if user and self.user_is_banned(user):
                 raise SessionException("You cannot attend this session")
-            if user and user.is_staff:
-                return True
-            if not self.space.published:
-                raise SessionException("Session is not available for signup")
-            if not self.open:
-                raise SessionException("Session is not available for signup")
-            if self.cancelled:
-                raise SessionException("Session was cancelled")
-            if self.started():
-                raise SessionException("Session has already started")
-            if self.seats_left() <= 0:
-                raise SessionException("There are no spots left")
+            if not (user and user.is_staff):
+                if not self.space.published:
+                    raise SessionException("Session is not available for signup")
+                if not self.open:
+                    raise SessionException("Session is not available for signup")
+                if self.cancelled:
+                    raise SessionException("Session was cancelled")
+                if self.started():
+                    raise SessionException("Session has already started")
+                if self.seats_left() <= 0:
+                    raise SessionException("There are no spots left")
+            if user:
+                conflicting_session = self.time_conflict_for(user, excluding=excluding_time_conflict)
+                if conflicting_session is not None:
+                    raise SessionTimeConflict(conflicting_session)
             return True
         except SessionException as e:
             if silent:
@@ -535,6 +565,12 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
 
 class SessionException(Exception):
     pass
+
+
+class SessionTimeConflict(SessionException):
+    def __init__(self, conflicting_session: Session):
+        self.conflicting_session = conflicting_session
+        super().__init__("This session conflicts with another session you are attending")
 
 
 class SessionFeedbackOptions(models.TextChoices):

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -120,18 +120,16 @@ class SessionQuerySet(models.QuerySet["Session"]):
             )
         )
 
+    def removable_attendance_for(self, user: "User") -> "SessionQuerySet":
+        """Visible sessions this user attends and can still give up."""
+        now = timezone.now()
+        return self.visible_to(user).not_ended().filter(attendees=user, start__gte=now)
+
     def time_conflicts_for(self, session: "Session", user: "User") -> "SessionQuerySet":
         """Visible, removable sessions this user attends that overlap ``session``."""
-        now = timezone.now()
         return (
-            self.visible_to(user)
-            .not_ended()
-            .filter(
-                attendees=user,
-                start__gte=now,
-                start__lt=session.end(),
-                session_end_time__gt=session.start,
-            )
+            self.removable_attendance_for(user)
+            .filter(start__lt=session.end(), session_end_time__gt=session.start)
             .exclude(pk=session.pk)
             .order_by("start", "pk")
         )

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -1,12 +1,13 @@
 import datetime
 import time
 from enum import Enum
+from functools import partial
 from typing import TYPE_CHECKING
 
 import pytz
 from django.conf import settings
 from django.core.validators import MaxValueValidator, MinValueValidator
-from django.db import models
+from django.db import models, transaction
 from django.db.models.query import QuerySet
 from django.urls import reverse
 from django.utils import timezone
@@ -398,9 +399,12 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
                 self.space.unsubscribe(user)
                 return False
             if not self.space.author == user:
-                notify_slack(
-                    f"✅ New session attendee: {self._get_slack_attendee_message(user)}",
-                    email_to_mention=self.space.author.email,
+                transaction.on_commit(
+                    partial(
+                        notify_slack,
+                        f"✅ New session attendee: {self._get_slack_attendee_message(user)}",
+                        email_to_mention=self.space.author.email,
+                    )
                 )
             return True
         return False
@@ -452,9 +456,12 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
         if self.started():
             raise SessionException("Session has already started")
         self.attendees.remove(user)
-        notify_slack(
-            f"🛑 Session attendee left: {self._get_slack_attendee_message(user)}",
-            email_to_mention=self.space.author.email,
+        transaction.on_commit(
+            partial(
+                notify_slack,
+                f"🛑 Session attendee left: {self._get_slack_attendee_message(user)}",
+                email_to_mention=self.space.author.email,
+            )
         )
 
     def _get_slack_attendee_message(self, user):

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -125,14 +125,16 @@ class SessionQuerySet(models.QuerySet["Session"]):
         now = timezone.now()
         return self.visible_to(user).not_ended().filter(attendees=user, start__gte=now)
 
+    def overlapping(self, session: "Session") -> "SessionQuerySet":
+        """Sessions whose half-open time interval overlaps ``session``."""
+        return self.annotate(session_end_time=SESSION_END_TIME).filter(
+            start__lt=session.end(),
+            session_end_time__gt=session.start,
+        )
+
     def time_conflicts_for(self, session: "Session", user: "User") -> "SessionQuerySet":
         """Visible, removable sessions this user attends that overlap ``session``."""
-        return (
-            self.removable_attendance_for(user)
-            .filter(start__lt=session.end(), session_end_time__gt=session.start)
-            .exclude(pk=session.pk)
-            .order_by("start", "pk")
-        )
+        return self.removable_attendance_for(user).overlapping(session).exclude(pk=session.pk).order_by("start", "pk")
 
 
 class SessionState(Enum):
@@ -322,10 +324,6 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
     def active_attendees(self) -> "QuerySet[User]":
         """Attendees, excluding users banned from this session's room."""
         return self._exclude_banned_users(self.attendees.all())
-
-    def overlaps(self, other: "Session") -> bool:
-        """Whether this session and another occupy any of the same time."""
-        return self.start < other.end() and self.end() > other.start
 
     def time_conflict_for(self, user: "User", excluding: "list[Session] | None" = None) -> "Session | None":
         """Return the first session this user is attending that overlaps this one."""

--- a/totem/spaces/models.py
+++ b/totem/spaces/models.py
@@ -313,9 +313,9 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
         """Whether this session and another occupy any of the same time."""
         return self.start < other.end() and self.end() > other.start
 
-    def time_conflict_for(self, user: "User", excluding: "Session | None" = None) -> "Session | None":
-        """Return the first session this user is attending that overlaps this one."""
-        sessions = (
+    def time_conflicts_for(self, user: "User") -> "SessionQuerySet":
+        """Return sessions this user is attending that overlap this one."""
+        return (
             Session.objects.filter(
                 attendees=user,
                 cancelled=False,
@@ -327,15 +327,19 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
             .exclude(pk=self.pk)
             .order_by("start", "pk")
         )
-        if excluding is not None:
-            sessions = sessions.exclude(pk=excluding.pk)
+
+    def time_conflict_for(self, user: "User", excluding: "list[Session] | None" = None) -> "Session | None":
+        """Return the first session this user is attending that overlaps this one."""
+        sessions = self.time_conflicts_for(user)
+        if excluding:
+            sessions = sessions.exclude(pk__in=[session.pk for session in excluding])
         return sessions.first()
 
     def can_attend(
         self,
         user: "User | None" = None,
         silent=False,
-        excluding_time_conflict: "Session | None" = None,
+        excluding_time_conflicts: "list[Session] | None" = None,
     ):
         try:
             if user and user in self.attendees.all():
@@ -354,7 +358,7 @@ class Session(AdminURLMixin, MarkdownMixin, SluggedModel):
                 if self.seats_left() <= 0:
                     raise SessionException("There are no spots left")
             if user:
-                conflicting_session = self.time_conflict_for(user, excluding=excluding_time_conflict)
+                conflicting_session = self.time_conflict_for(user, excluding=excluding_time_conflicts)
                 if conflicting_session is not None:
                     raise SessionTimeConflict(conflicting_session)
             return True

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 import pytest
 from django.db import connection
@@ -8,9 +9,10 @@ from django.urls import reverse
 from django.utils import timezone
 
 from totem.api.auth import generate_jwt_token
+from totem.email.exceptions import EmailBounced
 from totem.onboard.tests.factories import OnboardModelFactory
 from totem.rooms.models import Room
-from totem.spaces.models import SessionFeedback, SessionFeedbackOptions
+from totem.spaces.models import Session, SessionException, SessionFeedback, SessionFeedbackOptions
 from totem.spaces.tests.factories import SessionFactory, SpaceCategoryFactory, SpaceFactory
 from totem.users.models import User
 from totem.users.tests.factories import UserFactory
@@ -887,6 +889,109 @@ class TestMobileApiSpaces:
         assert not attending.attendees.filter(pk=user.pk).exists()
         assert event.attendees.filter(pk=user.pk).exists()
         assert event.space.subscribed.filter(pk=user.pk).exists()
+
+    def test_rsvp_resolve_conflicts_with_empty_list_behaves_like_plain_rsvp(
+        self, client_with_user: tuple[Client, User]
+    ):
+        client, user = client_with_user
+        event = SessionFactory(start=timezone.now() + timedelta(days=1))
+
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
+        response = client.post(
+            url,
+            {"conflicting_session_slugs": []},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.json()["attending"] is True
+        assert event.attendees.filter(pk=user.pk).exists()
+        assert event.space.subscribed.filter(pk=user.pk).exists()
+
+    def test_rsvp_resolve_conflicts_rejects_user_already_attending_target(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        event = SessionFactory(start=timezone.now() + timedelta(days=1))
+        event.attendees.add(user)
+
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
+        response = client.post(
+            url,
+            {"conflicting_session_slugs": []},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+        assert "already attending" in response.json()["detail"].lower()
+        assert event.attendees.filter(pk=user.pk).exists()
+
+    def test_rsvp_resolve_conflicts_rolls_back_when_signup_email_bounces(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        attending = SessionFactory(start=start, duration_minutes=60)
+        attending.attendees.add(user)
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
+
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
+        with patch("totem.spaces.models.notify_session_signup") as mock_email:
+            mock_email.return_value.send.side_effect = EmailBounced()
+            response = client.post(
+                url,
+                {"conflicting_session_slugs": [attending.slug]},
+                content_type="application/json",
+            )
+
+        assert response.status_code == 403
+        assert attending.attendees.filter(pk=user.pk).exists()
+        assert not event.attendees.filter(pk=user.pk).exists()
+        assert not event.space.subscribed.filter(pk=user.pk).exists()
+
+    def test_rsvp_resolve_conflicts_rolls_back_when_add_attendee_fails(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        attending = SessionFactory(start=start, duration_minutes=60)
+        attending.attendees.add(user)
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
+
+        def fail_after_conflicts_removed(target: Session, attendee: User, *, prevalidated: bool = False) -> bool:
+            assert target.pk == event.pk
+            assert attendee.pk == user.pk
+            assert prevalidated is True
+            assert not attending.attendees.filter(pk=user.pk).exists()
+            raise SessionException("Unable to add attendee")
+
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
+        with patch.object(Session, "add_attendee", autospec=True, side_effect=fail_after_conflicts_removed):
+            response = client.post(
+                url,
+                {"conflicting_session_slugs": [attending.slug]},
+                content_type="application/json",
+            )
+
+        assert response.status_code == 403
+        assert attending.attendees.filter(pk=user.pk).exists()
+        assert not event.attendees.filter(pk=user.pk).exists()
+
+    def test_rsvp_resolve_conflicts_rejects_user_banned_from_target(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        attending = SessionFactory(start=start, duration_minutes=60)
+        attending.attendees.add(user)
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
+        room = Room.objects.get_or_create_for_session(event)
+        room.banned_participants = [user.slug]
+        room.save()
+
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
+        response = client.post(
+            url,
+            {"conflicting_session_slugs": [attending.slug]},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+        assert "cannot attend" in response.json()["detail"].lower()
+        assert attending.attendees.filter(pk=user.pk).exists()
+        assert not event.attendees.filter(pk=user.pk).exists()
 
     def test_rsvp_resolve_conflicts_preserves_attendance_when_new_session_is_unavailable(
         self, client_with_user: tuple[Client, User]

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -764,8 +764,8 @@ class TestMobileApiSpaces:
     def test_rsvp_confirm_returns_all_conflicting_sessions(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
-        first = SessionFactory(start=start, duration_minutes=60)
-        second = SessionFactory(start=start + timedelta(minutes=45), duration_minutes=60)
+        first = SessionFactory(title="Earlier conflict", start=start, duration_minutes=60)
+        second = SessionFactory(title="Later conflict", start=start + timedelta(minutes=45), duration_minutes=60)
         first.attendees.add(user)
         second.attendees.add(user)
         event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
@@ -777,6 +777,10 @@ class TestMobileApiSpaces:
         data = response.json()
         assert data["message"] == "This session conflicts with one or more sessions you are attending"
         assert [session["slug"] for session in data["conflicting_sessions"]] == [first.slug, second.slug]
+        assert [session["title"] for session in data["conflicting_sessions"]] == [
+            "Earlier conflict",
+            "Later conflict",
+        ]
         assert all(session["attending"] is True for session in data["conflicting_sessions"])
         assert "slug" not in data
         assert not event.attendees.filter(pk=user.pk).exists()
@@ -864,6 +868,78 @@ class TestMobileApiSpaces:
         assert response.status_code == 403
         assert attending.attendees.filter(pk=user.pk).exists()
         assert not event.attendees.filter(pk=user.pk).exists()
+
+    def test_rsvp_switch_preserves_attendance_when_target_is_full(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        attending = SessionFactory(start=start, duration_minutes=60)
+        attending.attendees.add(user)
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60, seats=1)
+        event.attendees.add(UserFactory())
+
+        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        response = client.post(
+            url,
+            {"conflicting_session_slug": attending.slug},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+        assert "no spots left" in response.json()["detail"].lower()
+        assert attending.attendees.filter(pk=user.pk).exists()
+        assert not event.attendees.filter(pk=user.pk).exists()
+
+    def test_rsvp_switch_rejects_non_overlapping_session(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        attending = SessionFactory(start=start, duration_minutes=60)
+        attending.attendees.add(user)
+        event = SessionFactory(start=start + timedelta(hours=2), duration_minutes=60)
+
+        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        response = client.post(
+            url,
+            {"conflicting_session_slug": attending.slug},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Sessions do not conflict"
+        assert attending.attendees.filter(pk=user.pk).exists()
+        assert not event.attendees.filter(pk=user.pk).exists()
+
+    def test_rsvp_switch_rejects_session_user_is_not_attending(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        not_attending = SessionFactory(start=start, duration_minutes=60)
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
+
+        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        response = client.post(
+            url,
+            {"conflicting_session_slug": not_attending.slug},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 404
+        assert not event.attendees.filter(pk=user.pk).exists()
+
+    def test_rsvp_switch_keeps_started_conflicting_session(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        attending = SessionFactory(start=timezone.now() - timedelta(minutes=30), duration_minutes=60)
+        attending.attendees.add(user)
+        event = SessionFactory(start=timezone.now() + timedelta(minutes=10), duration_minutes=60)
+
+        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        response = client.post(
+            url,
+            {"conflicting_session_slug": attending.slug},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert attending.attendees.filter(pk=user.pk).exists()
+        assert event.attendees.filter(pk=user.pk).exists()
 
     def test_rsvp_switch_rejects_hidden_conflicting_session(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -817,13 +817,15 @@ class TestMobileApiSpaces:
         assert attending.attendees.filter(pk=user.pk).exists()
         assert not event.attendees.filter(pk=user.pk).exists()
 
-    def test_rsvp_switch_returns_another_remaining_conflict(self, client_with_user: tuple[Client, User]):
+    def test_rsvp_switch_replaces_all_conflicting_sessions(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
         first = SessionFactory(start=start, duration_minutes=60)
         second = SessionFactory(start=start + timedelta(minutes=45), duration_minutes=60)
+        non_conflicting = SessionFactory(start=start + timedelta(hours=2), duration_minutes=60)
         first.attendees.add(user)
         second.attendees.add(user)
+        non_conflicting.attendees.add(user)
         event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
 
         url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
@@ -833,11 +835,13 @@ class TestMobileApiSpaces:
             content_type="application/json",
         )
 
-        assert response.status_code == 409
-        assert response.json()["slug"] == second.slug
-        assert first.attendees.filter(pk=user.pk).exists()
-        assert second.attendees.filter(pk=user.pk).exists()
-        assert not event.attendees.filter(pk=user.pk).exists()
+        assert response.status_code == 200
+        assert response.json()["slug"] == event.slug
+        assert response.json()["attending"] is True
+        assert not first.attendees.filter(pk=user.pk).exists()
+        assert not second.attendees.filter(pk=user.pk).exists()
+        assert non_conflicting.attendees.filter(pk=user.pk).exists()
+        assert event.attendees.filter(pk=user.pk).exists()
 
     def test_rsvp_confirm_banned(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -792,6 +792,20 @@ class TestMobileApiSpaces:
         assert attending.attendees.filter(pk=user.pk).exists()
         assert event.attendees.filter(pk=user.pk).exists()
 
+    def test_rsvp_confirm_ignores_conflict_in_unpublished_space(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        draft = SessionFactory(space__published=False, start=start, duration_minutes=60)
+        draft.attendees.add(user)
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
+
+        url = reverse("mobile-api:rsvp_confirm", kwargs={"event_slug": event.slug})
+        response = client.post(url)
+
+        assert response.status_code == 200
+        assert draft.attendees.filter(pk=user.pk).exists()
+        assert event.attendees.filter(pk=user.pk).exists()
+
     def test_rsvp_switch_replaces_conflicting_session(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
@@ -831,6 +845,24 @@ class TestMobileApiSpaces:
 
         assert response.status_code == 403
         assert attending.attendees.filter(pk=user.pk).exists()
+        assert not event.attendees.filter(pk=user.pk).exists()
+
+    def test_rsvp_switch_rejects_hidden_conflicting_session(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        hidden = SessionFactory(space__published=False, start=start, duration_minutes=60)
+        hidden.attendees.add(user)
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
+
+        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        response = client.post(
+            url,
+            {"conflicting_session_slug": hidden.slug},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 404
+        assert hidden.attendees.filter(pk=user.pk).exists()
         assert not event.attendees.filter(pk=user.pk).exists()
 
     def test_rsvp_switch_staff_keeps_started_conflicting_session(self, client_with_user: tuple[Client, User]):

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -776,6 +776,22 @@ class TestMobileApiSpaces:
         assert response.json()["attending"] is True
         assert not event.attendees.filter(pk=user.pk).exists()
 
+    def test_rsvp_confirm_allows_staff_to_attend_overlapping_sessions(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        user.is_staff = True
+        user.save(update_fields=["is_staff"])
+        start = timezone.now() + timedelta(days=1)
+        attending = SessionFactory(start=start, duration_minutes=60)
+        attending.attendees.add(user)
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
+
+        url = reverse("mobile-api:rsvp_confirm", kwargs={"event_slug": event.slug})
+        response = client.post(url)
+
+        assert response.status_code == 200
+        assert attending.attendees.filter(pk=user.pk).exists()
+        assert event.attendees.filter(pk=user.pk).exists()
+
     def test_rsvp_switch_replaces_conflicting_session(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
@@ -816,6 +832,25 @@ class TestMobileApiSpaces:
         assert response.status_code == 403
         assert attending.attendees.filter(pk=user.pk).exists()
         assert not event.attendees.filter(pk=user.pk).exists()
+
+    def test_rsvp_switch_staff_keeps_started_conflicting_session(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        user.is_staff = True
+        user.save(update_fields=["is_staff"])
+        attending = SessionFactory(start=timezone.now() - timedelta(minutes=30), duration_minutes=60)
+        attending.attendees.add(user)
+        event = SessionFactory(start=timezone.now() + timedelta(minutes=15), duration_minutes=60)
+
+        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        response = client.post(
+            url,
+            {"conflicting_session_slug": attending.slug},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert attending.attendees.filter(pk=user.pk).exists()
+        assert event.attendees.filter(pk=user.pk).exists()
 
     def test_rsvp_switch_replaces_all_conflicting_sessions(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -806,6 +806,19 @@ class TestMobileApiSpaces:
         assert draft.attendees.filter(pk=user.pk).exists()
         assert event.attendees.filter(pk=user.pk).exists()
 
+    def test_rsvp_confirm_ignores_started_overlapping_session(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        attending = SessionFactory(start=timezone.now() - timedelta(minutes=30), duration_minutes=60)
+        attending.attendees.add(user)
+        event = SessionFactory(start=timezone.now() + timedelta(minutes=10), duration_minutes=60)
+
+        url = reverse("mobile-api:rsvp_confirm", kwargs={"event_slug": event.slug})
+        response = client.post(url)
+
+        assert response.status_code == 200
+        assert attending.attendees.filter(pk=user.pk).exists()
+        assert event.attendees.filter(pk=user.pk).exists()
+
     def test_rsvp_switch_replaces_conflicting_session(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -765,6 +765,19 @@ class TestMobileApiSpaces:
         assert data["slug"] == event.slug
         assert data["attending"] is True
 
+    def test_rsvp_confirm_does_not_resubscribe_after_signup_email_bounces(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        event = SessionFactory(space__published=True)
+        url = reverse("mobile-api:rsvp_confirm", kwargs={"event_slug": event.slug})
+
+        with patch("totem.spaces.models.notify_session_signup") as mock_email:
+            mock_email.return_value.send.side_effect = EmailBounced()
+            response = client.post(url)
+
+        assert response.status_code == 403
+        assert not event.attendees.filter(pk=user.pk).exists()
+        assert not event.space.subscribed.filter(pk=user.pk).exists()
+
     def test_rsvp_confirm_returns_all_conflicting_sessions(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
@@ -1129,6 +1142,10 @@ class TestMobileApiSpaces:
     def test_rsvp_resolve_conflicts_replaces_all_conflicting_sessions(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
+        single_start = start + timedelta(days=2)
+        single_conflict = SessionFactory(start=single_start, duration_minutes=60)
+        single_conflict.attendees.add(user)
+        single_event = SessionFactory(start=single_start + timedelta(minutes=30), duration_minutes=60)
         first = SessionFactory(start=start, duration_minutes=60)
         second = SessionFactory(start=start + timedelta(minutes=45), duration_minutes=60)
         non_conflicting = SessionFactory(start=start + timedelta(hours=2), duration_minutes=60)
@@ -1137,14 +1154,23 @@ class TestMobileApiSpaces:
         non_conflicting.attendees.add(user)
         event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
 
+        single_url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": single_event.slug})
         url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
-        with CaptureQueriesContext(connection) as queries:
-            response = client.post(
-                url,
-                {"conflicting_session_slugs": [first.slug, second.slug]},
-                content_type="application/json",
-            )
+        with patch("totem.spaces.models.notify_session_signup"):
+            with CaptureQueriesContext(connection) as single_conflict_queries:
+                single_response = client.post(
+                    single_url,
+                    {"conflicting_session_slugs": [single_conflict.slug]},
+                    content_type="application/json",
+                )
+            with CaptureQueriesContext(connection) as two_conflict_queries:
+                response = client.post(
+                    url,
+                    {"conflicting_session_slugs": [first.slug, second.slug]},
+                    content_type="application/json",
+                )
 
+        assert single_response.status_code == 200
         assert response.status_code == 200
         assert response.json()["slug"] == event.slug
         assert response.json()["attending"] is True
@@ -1152,7 +1178,8 @@ class TestMobileApiSpaces:
         assert not second.attendees.filter(pk=user.pk).exists()
         assert non_conflicting.attendees.filter(pk=user.pk).exists()
         assert event.attendees.filter(pk=user.pk).exists()
-        assert len(queries) <= 34
+        # One extra removal adds only the M2M select/delete and its audit select/insert.
+        assert len(two_conflict_queries) == len(single_conflict_queries) + 4
 
     def test_rsvp_resolve_conflicts_returns_fresh_409_for_unsubmitted_conflict(
         self, client_with_user: tuple[Client, User]

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -855,7 +855,7 @@ class TestMobileApiSpaces:
         url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
-            {"conflicting_session_slug": attending.slug},
+            {"conflicting_session_slugs": [attending.slug]},
             content_type="application/json",
         )
 
@@ -878,7 +878,7 @@ class TestMobileApiSpaces:
         url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
-            {"conflicting_session_slug": attending.slug},
+            {"conflicting_session_slugs": [attending.slug]},
             content_type="application/json",
         )
 
@@ -899,7 +899,7 @@ class TestMobileApiSpaces:
         url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
-            {"conflicting_session_slug": attending.slug},
+            {"conflicting_session_slugs": [attending.slug]},
             content_type="application/json",
         )
 
@@ -918,7 +918,7 @@ class TestMobileApiSpaces:
         url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
-            {"conflicting_session_slug": attending.slug},
+            {"conflicting_session_slugs": [attending.slug]},
             content_type="application/json",
         )
 
@@ -936,7 +936,7 @@ class TestMobileApiSpaces:
         url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
-            {"conflicting_session_slug": not_attending.slug},
+            {"conflicting_session_slugs": [not_attending.slug]},
             content_type="application/json",
         )
 
@@ -952,7 +952,7 @@ class TestMobileApiSpaces:
         url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
-            {"conflicting_session_slug": attending.slug},
+            {"conflicting_session_slugs": [attending.slug]},
             content_type="application/json",
         )
 
@@ -970,7 +970,7 @@ class TestMobileApiSpaces:
         url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
-            {"conflicting_session_slug": hidden.slug},
+            {"conflicting_session_slugs": [hidden.slug]},
             content_type="application/json",
         )
 
@@ -991,7 +991,7 @@ class TestMobileApiSpaces:
         url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
-            {"conflicting_session_slug": attending.slug},
+            {"conflicting_session_slugs": [attending.slug]},
             content_type="application/json",
         )
 
@@ -1013,7 +1013,7 @@ class TestMobileApiSpaces:
         url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
-            {"conflicting_session_slug": first.slug},
+            {"conflicting_session_slugs": [first.slug, second.slug]},
             content_type="application/json",
         )
 
@@ -1024,6 +1024,33 @@ class TestMobileApiSpaces:
         assert not second.attendees.filter(pk=user.pk).exists()
         assert non_conflicting.attendees.filter(pk=user.pk).exists()
         assert event.attendees.filter(pk=user.pk).exists()
+
+    def test_rsvp_resolve_conflicts_returns_fresh_409_for_unsubmitted_conflict(
+        self, client_with_user: tuple[Client, User]
+    ):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        consented = SessionFactory(start=start, duration_minutes=60)
+        newly_conflicting = SessionFactory(start=start + timedelta(minutes=45), duration_minutes=60)
+        consented.attendees.add(user)
+        newly_conflicting.attendees.add(user)
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
+
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
+        response = client.post(
+            url,
+            {"conflicting_session_slugs": [consented.slug]},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 409
+        assert {item["slug"] for item in response.json()["conflicting_sessions"]} == {
+            consented.slug,
+            newly_conflicting.slug,
+        }
+        assert consented.attendees.filter(pk=user.pk).exists()
+        assert newly_conflicting.attendees.filter(pk=user.pk).exists()
+        assert not event.attendees.filter(pk=user.pk).exists()
 
     def test_rsvp_confirm_banned(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -972,7 +972,9 @@ class TestMobileApiSpaces:
         assert not event.attendees.filter(pk=user.pk).exists()
         assert not event.space.subscribed.filter(pk=user.pk).exists()
 
-    def test_rsvp_resolve_conflicts_rolls_back_when_add_attendee_fails(self, client_with_user: tuple[Client, User]):
+    def test_rsvp_resolve_conflicts_rolls_back_when_add_attendee_fails(
+        self, client_with_user: tuple[Client, User], django_capture_on_commit_callbacks
+    ):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
         attending = SessionFactory(start=start, duration_minutes=60)
@@ -987,7 +989,11 @@ class TestMobileApiSpaces:
             raise SessionException("Unable to add attendee")
 
         url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
-        with patch.object(Session, "add_attendee", autospec=True, side_effect=fail_after_conflicts_removed):
+        with (
+            patch("totem.spaces.models.notify_slack") as mock_slack,
+            django_capture_on_commit_callbacks(execute=True) as callbacks,
+            patch.object(Session, "add_attendee", autospec=True, side_effect=fail_after_conflicts_removed),
+        ):
             response = client.post(
                 url,
                 {"conflicting_session_slugs": [attending.slug]},
@@ -997,6 +1003,8 @@ class TestMobileApiSpaces:
         assert response.status_code == 403
         assert attending.attendees.filter(pk=user.pk).exists()
         assert not event.attendees.filter(pk=user.pk).exists()
+        assert callbacks == []
+        mock_slack.assert_not_called()
 
     def test_rsvp_resolve_conflicts_rejects_user_banned_from_target(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -761,6 +761,84 @@ class TestMobileApiSpaces:
         assert data["slug"] == event.slug
         assert data["attending"] is True
 
+    def test_rsvp_confirm_returns_conflicting_session(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        attending = SessionFactory(start=start, duration_minutes=60)
+        attending.attendees.add(user)
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
+
+        url = reverse("mobile-api:rsvp_confirm", kwargs={"event_slug": event.slug})
+        response = client.post(url)
+
+        assert response.status_code == 409
+        assert response.json()["slug"] == attending.slug
+        assert response.json()["attending"] is True
+        assert not event.attendees.filter(pk=user.pk).exists()
+
+    def test_rsvp_switch_replaces_conflicting_session(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        attending = SessionFactory(start=start, duration_minutes=60)
+        attending.attendees.add(user)
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
+
+        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        response = client.post(
+            url,
+            {"conflicting_session_slug": attending.slug},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.json()["slug"] == event.slug
+        assert response.json()["attending"] is True
+        assert not attending.attendees.filter(pk=user.pk).exists()
+        assert event.attendees.filter(pk=user.pk).exists()
+        assert event.space.subscribed.filter(pk=user.pk).exists()
+
+    def test_rsvp_switch_preserves_attendance_when_new_session_is_unavailable(
+        self, client_with_user: tuple[Client, User]
+    ):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        attending = SessionFactory(start=start, duration_minutes=60)
+        attending.attendees.add(user)
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60, open=False)
+
+        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        response = client.post(
+            url,
+            {"conflicting_session_slug": attending.slug},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+        assert attending.attendees.filter(pk=user.pk).exists()
+        assert not event.attendees.filter(pk=user.pk).exists()
+
+    def test_rsvp_switch_returns_another_remaining_conflict(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        first = SessionFactory(start=start, duration_minutes=60)
+        second = SessionFactory(start=start + timedelta(minutes=45), duration_minutes=60)
+        first.attendees.add(user)
+        second.attendees.add(user)
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
+
+        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        response = client.post(
+            url,
+            {"conflicting_session_slug": first.slug},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 409
+        assert response.json()["slug"] == second.slug
+        assert first.attendees.filter(pk=user.pk).exists()
+        assert second.attendees.filter(pk=user.pk).exists()
+        assert not event.attendees.filter(pk=user.pk).exists()
+
     def test_rsvp_confirm_banned(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         event = SessionFactory(space__published=True)

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -1,7 +1,9 @@
 from datetime import timedelta
 
 import pytest
+from django.db import connection
 from django.test import Client
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
 
@@ -785,6 +787,26 @@ class TestMobileApiSpaces:
         assert "slug" not in data
         assert not event.attendees.filter(pk=user.pk).exists()
 
+    def test_rsvp_conflict_response_queries_do_not_scale_with_conflicts(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        first = SessionFactory(start=start, duration_minutes=60)
+        first.attendees.add(user)
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
+        url = reverse("mobile-api:rsvp_confirm", kwargs={"event_slug": event.slug})
+
+        with CaptureQueriesContext(connection) as one_conflict_queries:
+            one_conflict_response = client.post(url)
+
+        second = SessionFactory(start=start + timedelta(minutes=45), duration_minutes=60)
+        second.attendees.add(user)
+        with CaptureQueriesContext(connection) as two_conflict_queries:
+            two_conflict_response = client.post(url)
+
+        assert one_conflict_response.status_code == 409
+        assert two_conflict_response.status_code == 409
+        assert len(two_conflict_queries) == len(one_conflict_queries)
+
     def test_rsvp_confirm_allows_staff_to_attend_overlapping_sessions(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         user.is_staff = True
@@ -1011,11 +1033,12 @@ class TestMobileApiSpaces:
         event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
 
         url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
-        response = client.post(
-            url,
-            {"conflicting_session_slugs": [first.slug, second.slug]},
-            content_type="application/json",
-        )
+        with CaptureQueriesContext(connection) as queries:
+            response = client.post(
+                url,
+                {"conflicting_session_slugs": [first.slug, second.slug]},
+                content_type="application/json",
+            )
 
         assert response.status_code == 200
         assert response.json()["slug"] == event.slug
@@ -1024,6 +1047,7 @@ class TestMobileApiSpaces:
         assert not second.attendees.filter(pk=user.pk).exists()
         assert non_conflicting.attendees.filter(pk=user.pk).exists()
         assert event.attendees.filter(pk=user.pk).exists()
+        assert len(queries) <= 34
 
     def test_rsvp_resolve_conflicts_returns_fresh_409_for_unsubmitted_conflict(
         self, client_with_user: tuple[Client, User]

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -815,6 +815,23 @@ class TestMobileApiSpaces:
         assert draft.attendees.filter(pk=user.pk).exists()
         assert event.attendees.filter(pk=user.pk).exists()
 
+    def test_rsvp_confirm_ignores_session_user_is_banned_from(self, client_with_user: tuple[Client, User]):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        banned = SessionFactory(start=start, duration_minutes=60)
+        banned.attendees.add(user)
+        room = Room.objects.get_or_create_for_session(banned)
+        room.banned_participants = [user.slug]
+        room.save()
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
+
+        url = reverse("mobile-api:rsvp_confirm", kwargs={"event_slug": event.slug})
+        response = client.post(url)
+
+        assert response.status_code == 200
+        assert banned.attendees.filter(pk=user.pk).exists()
+        assert event.attendees.filter(pk=user.pk).exists()
+
     def test_rsvp_confirm_ignores_started_overlapping_session(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         attending = SessionFactory(start=timezone.now() - timedelta(minutes=30), duration_minutes=60)

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -828,14 +828,14 @@ class TestMobileApiSpaces:
         assert attending.attendees.filter(pk=user.pk).exists()
         assert event.attendees.filter(pk=user.pk).exists()
 
-    def test_rsvp_switch_replaces_conflicting_session(self, client_with_user: tuple[Client, User]):
+    def test_rsvp_resolve_conflicts_replaces_conflicting_session(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
         attending = SessionFactory(start=start, duration_minutes=60)
         attending.attendees.add(user)
         event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
 
-        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
             {"conflicting_session_slug": attending.slug},
@@ -849,7 +849,7 @@ class TestMobileApiSpaces:
         assert event.attendees.filter(pk=user.pk).exists()
         assert event.space.subscribed.filter(pk=user.pk).exists()
 
-    def test_rsvp_switch_preserves_attendance_when_new_session_is_unavailable(
+    def test_rsvp_resolve_conflicts_preserves_attendance_when_new_session_is_unavailable(
         self, client_with_user: tuple[Client, User]
     ):
         client, user = client_with_user
@@ -858,7 +858,7 @@ class TestMobileApiSpaces:
         attending.attendees.add(user)
         event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60, open=False)
 
-        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
             {"conflicting_session_slug": attending.slug},
@@ -869,7 +869,9 @@ class TestMobileApiSpaces:
         assert attending.attendees.filter(pk=user.pk).exists()
         assert not event.attendees.filter(pk=user.pk).exists()
 
-    def test_rsvp_switch_preserves_attendance_when_target_is_full(self, client_with_user: tuple[Client, User]):
+    def test_rsvp_resolve_conflicts_preserves_attendance_when_target_is_full(
+        self, client_with_user: tuple[Client, User]
+    ):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
         attending = SessionFactory(start=start, duration_minutes=60)
@@ -877,7 +879,7 @@ class TestMobileApiSpaces:
         event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60, seats=1)
         event.attendees.add(UserFactory())
 
-        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
             {"conflicting_session_slug": attending.slug},
@@ -889,14 +891,14 @@ class TestMobileApiSpaces:
         assert attending.attendees.filter(pk=user.pk).exists()
         assert not event.attendees.filter(pk=user.pk).exists()
 
-    def test_rsvp_switch_rejects_non_overlapping_session(self, client_with_user: tuple[Client, User]):
+    def test_rsvp_resolve_conflicts_rejects_non_overlapping_session(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
         attending = SessionFactory(start=start, duration_minutes=60)
         attending.attendees.add(user)
         event = SessionFactory(start=start + timedelta(hours=2), duration_minutes=60)
 
-        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
             {"conflicting_session_slug": attending.slug},
@@ -908,13 +910,13 @@ class TestMobileApiSpaces:
         assert attending.attendees.filter(pk=user.pk).exists()
         assert not event.attendees.filter(pk=user.pk).exists()
 
-    def test_rsvp_switch_rejects_session_user_is_not_attending(self, client_with_user: tuple[Client, User]):
+    def test_rsvp_resolve_conflicts_rejects_session_user_is_not_attending(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
         not_attending = SessionFactory(start=start, duration_minutes=60)
         event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
 
-        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
             {"conflicting_session_slug": not_attending.slug},
@@ -924,13 +926,13 @@ class TestMobileApiSpaces:
         assert response.status_code == 404
         assert not event.attendees.filter(pk=user.pk).exists()
 
-    def test_rsvp_switch_keeps_started_conflicting_session(self, client_with_user: tuple[Client, User]):
+    def test_rsvp_resolve_conflicts_keeps_started_conflicting_session(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         attending = SessionFactory(start=timezone.now() - timedelta(minutes=30), duration_minutes=60)
         attending.attendees.add(user)
         event = SessionFactory(start=timezone.now() + timedelta(minutes=10), duration_minutes=60)
 
-        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
             {"conflicting_session_slug": attending.slug},
@@ -941,14 +943,14 @@ class TestMobileApiSpaces:
         assert attending.attendees.filter(pk=user.pk).exists()
         assert event.attendees.filter(pk=user.pk).exists()
 
-    def test_rsvp_switch_rejects_hidden_conflicting_session(self, client_with_user: tuple[Client, User]):
+    def test_rsvp_resolve_conflicts_rejects_hidden_conflicting_session(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
         hidden = SessionFactory(space__published=False, start=start, duration_minutes=60)
         hidden.attendees.add(user)
         event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
 
-        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
             {"conflicting_session_slug": hidden.slug},
@@ -959,7 +961,9 @@ class TestMobileApiSpaces:
         assert hidden.attendees.filter(pk=user.pk).exists()
         assert not event.attendees.filter(pk=user.pk).exists()
 
-    def test_rsvp_switch_staff_keeps_started_conflicting_session(self, client_with_user: tuple[Client, User]):
+    def test_rsvp_resolve_conflicts_staff_keeps_started_conflicting_session(
+        self, client_with_user: tuple[Client, User]
+    ):
         client, user = client_with_user
         user.is_staff = True
         user.save(update_fields=["is_staff"])
@@ -967,7 +971,7 @@ class TestMobileApiSpaces:
         attending.attendees.add(user)
         event = SessionFactory(start=timezone.now() + timedelta(minutes=15), duration_minutes=60)
 
-        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
             {"conflicting_session_slug": attending.slug},
@@ -978,7 +982,7 @@ class TestMobileApiSpaces:
         assert attending.attendees.filter(pk=user.pk).exists()
         assert event.attendees.filter(pk=user.pk).exists()
 
-    def test_rsvp_switch_replaces_all_conflicting_sessions(self, client_with_user: tuple[Client, User]):
+    def test_rsvp_resolve_conflicts_replaces_all_conflicting_sessions(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
         first = SessionFactory(start=start, duration_minutes=60)
@@ -989,7 +993,7 @@ class TestMobileApiSpaces:
         non_conflicting.attendees.add(user)
         event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
 
-        url = reverse("mobile-api:rsvp_switch", kwargs={"event_slug": event.slug})
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
         response = client.post(
             url,
             {"conflicting_session_slug": first.slug},

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -1048,7 +1048,7 @@ class TestMobileApiSpaces:
         assert attending.attendees.filter(pk=user.pk).exists()
         assert not event.attendees.filter(pk=user.pk).exists()
 
-    def test_rsvp_resolve_conflicts_rejects_non_overlapping_session(self, client_with_user: tuple[Client, User]):
+    def test_rsvp_resolve_conflicts_ignores_non_overlapping_session(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
         attending = SessionFactory(start=start, duration_minutes=60)
@@ -1062,12 +1062,11 @@ class TestMobileApiSpaces:
             content_type="application/json",
         )
 
-        assert response.status_code == 403
-        assert response.json()["detail"] == "Sessions do not conflict"
+        assert response.status_code == 200
         assert attending.attendees.filter(pk=user.pk).exists()
-        assert not event.attendees.filter(pk=user.pk).exists()
+        assert event.attendees.filter(pk=user.pk).exists()
 
-    def test_rsvp_resolve_conflicts_rejects_session_user_is_not_attending(self, client_with_user: tuple[Client, User]):
+    def test_rsvp_resolve_conflicts_ignores_session_user_is_not_attending(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
         not_attending = SessionFactory(start=start, duration_minutes=60)
@@ -1080,8 +1079,8 @@ class TestMobileApiSpaces:
             content_type="application/json",
         )
 
-        assert response.status_code == 404
-        assert not event.attendees.filter(pk=user.pk).exists()
+        assert response.status_code == 200
+        assert event.attendees.filter(pk=user.pk).exists()
 
     def test_rsvp_resolve_conflicts_keeps_started_conflicting_session(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
@@ -1100,7 +1099,7 @@ class TestMobileApiSpaces:
         assert attending.attendees.filter(pk=user.pk).exists()
         assert event.attendees.filter(pk=user.pk).exists()
 
-    def test_rsvp_resolve_conflicts_rejects_hidden_conflicting_session(self, client_with_user: tuple[Client, User]):
+    def test_rsvp_resolve_conflicts_ignores_hidden_conflicting_session(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
         hidden = SessionFactory(space__published=False, start=start, duration_minutes=60)
@@ -1114,9 +1113,29 @@ class TestMobileApiSpaces:
             content_type="application/json",
         )
 
-        assert response.status_code == 404
+        assert response.status_code == 200
         assert hidden.attendees.filter(pk=user.pk).exists()
-        assert not event.attendees.filter(pk=user.pk).exists()
+        assert event.attendees.filter(pk=user.pk).exists()
+
+    def test_rsvp_resolve_conflicts_ignores_cancelled_and_unknown_submitted_sessions(
+        self, client_with_user: tuple[Client, User]
+    ):
+        client, user = client_with_user
+        start = timezone.now() + timedelta(days=1)
+        cancelled = SessionFactory(start=start, duration_minutes=60, cancelled=True)
+        cancelled.attendees.add(user)
+        event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
+
+        url = reverse("mobile-api:rsvp_resolve_conflicts", kwargs={"event_slug": event.slug})
+        response = client.post(
+            url,
+            {"conflicting_session_slugs": [cancelled.slug, "no-longer-exists"]},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert cancelled.attendees.filter(pk=user.pk).exists()
+        assert event.attendees.filter(pk=user.pk).exists()
 
     def test_rsvp_resolve_conflicts_staff_keeps_started_conflicting_session(
         self, client_with_user: tuple[Client, User]

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -761,19 +761,24 @@ class TestMobileApiSpaces:
         assert data["slug"] == event.slug
         assert data["attending"] is True
 
-    def test_rsvp_confirm_returns_conflicting_session(self, client_with_user: tuple[Client, User]):
+    def test_rsvp_confirm_returns_all_conflicting_sessions(self, client_with_user: tuple[Client, User]):
         client, user = client_with_user
         start = timezone.now() + timedelta(days=1)
-        attending = SessionFactory(start=start, duration_minutes=60)
-        attending.attendees.add(user)
+        first = SessionFactory(start=start, duration_minutes=60)
+        second = SessionFactory(start=start + timedelta(minutes=45), duration_minutes=60)
+        first.attendees.add(user)
+        second.attendees.add(user)
         event = SessionFactory(start=start + timedelta(minutes=30), duration_minutes=60)
 
         url = reverse("mobile-api:rsvp_confirm", kwargs={"event_slug": event.slug})
         response = client.post(url)
 
         assert response.status_code == 409
-        assert response.json()["slug"] == attending.slug
-        assert response.json()["attending"] is True
+        data = response.json()
+        assert data["message"] == "This session conflicts with one or more sessions you are attending"
+        assert [session["slug"] for session in data["conflicting_sessions"]] == [first.slug, second.slug]
+        assert all(session["attending"] is True for session in data["conflicting_sessions"])
+        assert "slug" not in data
         assert not event.attendees.filter(pk=user.pk).exists()
 
     def test_rsvp_confirm_allows_staff_to_attend_overlapping_sessions(self, client_with_user: tuple[Client, User]):

--- a/totem/spaces/tests/test_mobile_api.py
+++ b/totem/spaces/tests/test_mobile_api.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from django.db import connection
+from django.db.models import Prefetch
 from django.test import Client
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
@@ -12,7 +13,8 @@ from totem.api.auth import generate_jwt_token
 from totem.email.exceptions import EmailBounced
 from totem.onboard.tests.factories import OnboardModelFactory
 from totem.rooms.models import Room
-from totem.spaces.models import Session, SessionException, SessionFeedback, SessionFeedbackOptions
+from totem.spaces.mobile_api.mobile_filters import space_detail_schema
+from totem.spaces.models import Session, SessionException, SessionFeedback, SessionFeedbackOptions, Space, SpaceCategory
 from totem.spaces.tests.factories import SessionFactory, SpaceCategoryFactory, SpaceFactory
 from totem.users.models import User
 from totem.users.tests.factories import UserFactory
@@ -523,6 +525,18 @@ class TestMobileApiSpaces:
         slugs = [item["space"]["slug"] for item in data]
         assert len(slugs) == len(set(slugs)), f"Duplicates found in results: {slugs}"
         assert len(data) == 2
+
+    def test_space_detail_uses_lowest_pk_category_when_prefetched(self, client_with_user: tuple[Client, User]):
+        _, user = client_with_user
+        first = SpaceCategoryFactory(name="First")
+        second = SpaceCategoryFactory(name="Second")
+        space = SpaceFactory(published=True, categories=[first, second])
+
+        space = Space.objects.prefetch_related(
+            Prefetch("categories", queryset=SpaceCategory.objects.order_by("-pk"))
+        ).get(pk=space.pk)
+
+        assert space_detail_schema(space, user).category == first.name
 
     def test_recommended_spaces_handles_name_and_slug_mixed(self, client_with_user: tuple[Client, User]):
         client, _ = client_with_user

--- a/totem/spaces/tests/test_models.py
+++ b/totem/spaces/tests/test_models.py
@@ -13,7 +13,7 @@ from totem.users.models import User
 from totem.users.tests.factories import UserFactory
 from totem.utils.testing import email_text
 
-from ..models import Session, SessionException
+from ..models import Session, SessionException, SessionTimeConflict
 from ..views import ics_hash
 from .factories import SessionFactory, SpaceFactory
 
@@ -482,6 +482,36 @@ class TestSessionModel:
         assert session.can_attend(user=user, silent=True) is False
         with pytest.raises(SessionException, match="already started"):
             session.can_attend(user=user)
+
+    def test_can_attend_rejects_overlapping_session(self, db):
+        user = UserFactory()
+        start = timezone.now() + timezone.timedelta(days=1)
+        attending = SessionFactory(start=start, duration_minutes=60)
+        attending.attendees.add(user)
+        session = SessionFactory(start=start + timezone.timedelta(minutes=30), duration_minutes=60)
+
+        with pytest.raises(SessionTimeConflict) as exc_info:
+            session.can_attend(user=user)
+
+        assert exc_info.value.conflicting_session == attending
+
+    def test_can_attend_allows_back_to_back_session(self, db):
+        user = UserFactory()
+        start = timezone.now() + timezone.timedelta(days=1)
+        attending = SessionFactory(start=start, duration_minutes=60)
+        attending.attendees.add(user)
+        session = SessionFactory(start=start + timezone.timedelta(minutes=60), duration_minutes=60)
+
+        assert session.can_attend(user=user) is True
+
+    def test_cancelled_session_does_not_conflict(self, db):
+        user = UserFactory()
+        start = timezone.now() + timezone.timedelta(days=1)
+        attending = SessionFactory(start=start, duration_minutes=60, cancelled=True)
+        attending.attendees.add(user)
+        session = SessionFactory(start=start + timezone.timedelta(minutes=30), duration_minutes=60)
+
+        assert session.can_attend(user=user) is True
 
     def test_advertise_skips_banned(self, db):
         user = UserFactory()

--- a/totem/spaces/tests/test_models.py
+++ b/totem/spaces/tests/test_models.py
@@ -513,6 +513,16 @@ class TestSessionModel:
 
         assert session.can_attend(user=user) is True
 
+    def test_can_attend_ignores_session_user_is_banned_from(self, db):
+        user = UserFactory()
+        start = timezone.now() + timezone.timedelta(days=1)
+        banned = SessionFactory(start=start, duration_minutes=60)
+        banned.attendees.add(user)
+        _ban_user(banned, user)
+        session = SessionFactory(start=start + timezone.timedelta(minutes=30), duration_minutes=60)
+
+        assert session.can_attend(user=user) is True
+
     def test_can_attend_ignores_started_overlapping_session(self, db):
         user = UserFactory()
         attending = SessionFactory(

--- a/totem/spaces/tests/test_models.py
+++ b/totem/spaces/tests/test_models.py
@@ -513,6 +513,17 @@ class TestSessionModel:
 
         assert session.can_attend(user=user) is True
 
+    def test_can_attend_ignores_started_overlapping_session(self, db):
+        user = UserFactory()
+        attending = SessionFactory(
+            start=timezone.now() - timezone.timedelta(minutes=30),
+            duration_minutes=60,
+        )
+        attending.attendees.add(user)
+        session = SessionFactory(start=timezone.now() + timezone.timedelta(minutes=10), duration_minutes=60)
+
+        assert session.can_attend(user=user) is True
+
     def test_can_attend_allows_back_to_back_session(self, db):
         user = UserFactory()
         start = timezone.now() + timezone.timedelta(days=1)

--- a/totem/spaces/tests/test_models.py
+++ b/totem/spaces/tests/test_models.py
@@ -495,6 +495,15 @@ class TestSessionModel:
 
         assert exc_info.value.conflicting_session == attending
 
+    def test_can_attend_staff_allows_overlapping_session(self, db):
+        staff = UserFactory(is_staff=True)
+        start = timezone.now() + timezone.timedelta(days=1)
+        attending = SessionFactory(start=start, duration_minutes=60)
+        attending.attendees.add(staff)
+        session = SessionFactory(start=start + timezone.timedelta(minutes=30), duration_minutes=60)
+
+        assert session.can_attend(user=staff) is True
+
     def test_can_attend_allows_back_to_back_session(self, db):
         user = UserFactory()
         start = timezone.now() + timezone.timedelta(days=1)

--- a/totem/spaces/tests/test_models.py
+++ b/totem/spaces/tests/test_models.py
@@ -504,6 +504,15 @@ class TestSessionModel:
 
         assert session.can_attend(user=staff) is True
 
+    def test_can_attend_ignores_session_in_unpublished_space(self, db):
+        user = UserFactory()
+        start = timezone.now() + timezone.timedelta(days=1)
+        draft = SessionFactory(space__published=False, start=start, duration_minutes=60)
+        draft.attendees.add(user)
+        session = SessionFactory(start=start + timezone.timedelta(minutes=30), duration_minutes=60)
+
+        assert session.can_attend(user=user) is True
+
     def test_can_attend_allows_back_to_back_session(self, db):
         user = UserFactory()
         start = timezone.now() + timezone.timedelta(days=1)

--- a/totem/spaces/tests/test_models.py
+++ b/totem/spaces/tests/test_models.py
@@ -493,7 +493,7 @@ class TestSessionModel:
         with pytest.raises(SessionTimeConflict) as exc_info:
             session.can_attend(user=user)
 
-        assert exc_info.value.conflicting_session == attending
+        assert attending in exc_info.value.conflicting_sessions
 
     def test_can_attend_staff_allows_overlapping_session(self, db):
         staff = UserFactory(is_staff=True)


### PR DESCRIPTION
/rsvp/{event}/switch gives up spots for any overlapping sessions and attends the given session.

/rsvp/{event} returns an error when there is an overlapping session.